### PR TITLE
crawl for geom_alt prop updates

### DIFF
--- a/data/102/047/495/102047495.geojson
+++ b/data/102/047/495/102047495.geojson
@@ -24,8 +24,7 @@
     "src:geom_alt":[],
     "src:lbl_centroid":"mapshaper",
     "wof:belongsto":[
-        102191581,
-        85633129
+        102191581
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -37,7 +36,7 @@
     "wof:hierarchy":[
         {
             "continent_id":102191581,
-            "country_id":85633129,
+            "country_id":-1,
             "timezone_id":102047495
         }
     ],
@@ -45,9 +44,9 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566655699,
+    "wof:lastmodified":1579653767,
     "wof:name":"Europe/Madrid",
-    "wof:parent_id":85633129,
+    "wof:parent_id":102191581,
     "wof:placetype":"timezone",
     "wof:repo":"whosonfirst-data-admin-xy",
     "wof:superseded_by":[],

--- a/data/102/047/619/102047619.geojson
+++ b/data/102/047/619/102047619.geojson
@@ -24,6 +24,7 @@
     "src:geom_alt":[],
     "src:lbl_centroid":"mapshaper",
     "wof:belongsto":[
+        102191581,
         85633735
     ],
     "wof:breaches":[],
@@ -35,7 +36,7 @@
     "wof:geomhash":"c0a8baf397adf4446aa500929fa463eb",
     "wof:hierarchy":[
         {
-            "continent_id":-1,
+            "continent_id":102191581,
             "country_id":85633735,
             "timezone_id":102047619
         }
@@ -44,7 +45,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566655546,
+    "wof:lastmodified":1579653767,
     "wof:name":"Atlantic/Azores",
     "wof:parent_id":85633735,
     "wof:placetype":"timezone",

--- a/data/102/191/569/102191569.geojson
+++ b/data/102/191/569/102191569.geojson
@@ -950,6 +950,9 @@
         "wk:page":"Asia"
     },
     "wof:country":"",
+    "wof:geom_alt":[
+        "naturalearth"
+    ],
     "wof:geomhash":"fcf26131e980703079d31e1947df5c4a",
     "wof:hierarchy":[
         {
@@ -957,7 +960,7 @@
         }
     ],
     "wof:id":102191569,
-    "wof:lastmodified":1566656388,
+    "wof:lastmodified":1582332120,
     "wof:name":"Asia",
     "wof:parent_id":-1,
     "wof:placetype":"continent",

--- a/data/102/191/573/102191573.geojson
+++ b/data/102/191/573/102191573.geojson
@@ -976,6 +976,9 @@
         "wk:page":"Africa"
     },
     "wof:country":"",
+    "wof:geom_alt":[
+        "naturalearth"
+    ],
     "wof:geomhash":"b2d07c8ef8b5eefb0b0bc5c9be379eed",
     "wof:hierarchy":[
         {
@@ -983,7 +986,7 @@
         }
     ],
     "wof:id":102191573,
-    "wof:lastmodified":1566656409,
+    "wof:lastmodified":1582332136,
     "wof:name":"Africa",
     "wof:parent_id":-1,
     "wof:placetype":"continent",

--- a/data/102/191/575/102191575.geojson
+++ b/data/102/191/575/102191575.geojson
@@ -831,6 +831,9 @@
         "wk:page":"North_America"
     },
     "wof:country":"",
+    "wof:geom_alt":[
+        "naturalearth"
+    ],
     "wof:geomhash":"2613e4eb6a8264590baf3b694e4c9cce",
     "wof:hierarchy":[
         {
@@ -838,7 +841,7 @@
         }
     ],
     "wof:id":102191575,
-    "wof:lastmodified":1566656402,
+    "wof:lastmodified":1582332130,
     "wof:name":"North America",
     "wof:parent_id":-1,
     "wof:placetype":"continent",

--- a/data/102/191/577/102191577.geojson
+++ b/data/102/191/577/102191577.geojson
@@ -792,6 +792,9 @@
         "wk:page":"South_America"
     },
     "wof:country":"",
+    "wof:geom_alt":[
+        "naturalearth"
+    ],
     "wof:geomhash":"e8080769d4954cffe06ea8c80fa9fa61",
     "wof:hierarchy":[
         {
@@ -799,7 +802,7 @@
         }
     ],
     "wof:id":102191577,
-    "wof:lastmodified":1566656412,
+    "wof:lastmodified":1582332138,
     "wof:name":"South America",
     "wof:parent_id":-1,
     "wof:placetype":"continent",

--- a/data/102/191/581/102191581.geojson
+++ b/data/102/191/581/102191581.geojson
@@ -937,6 +937,9 @@
         "wk:page":"Europe"
     },
     "wof:country":"",
+    "wof:geom_alt":[
+        "naturalearth"
+    ],
     "wof:geomhash":"4fd1897af30b08de7bee66d7e4ce067b",
     "wof:hierarchy":[
         {
@@ -944,7 +947,7 @@
         }
     ],
     "wof:id":102191581,
-    "wof:lastmodified":1566656395,
+    "wof:lastmodified":1582332125,
     "wof:name":"Europe",
     "wof:parent_id":-1,
     "wof:placetype":"continent",

--- a/data/102/525/967/102525967.geojson
+++ b/data/102/525/967/102525967.geojson
@@ -52,6 +52,7 @@
         85681955,
         102191577,
         85633009,
+        1511777413,
         101961739,
         102055403
     ],
@@ -72,11 +73,13 @@
             "country_id":85633009,
             "county_id":102055403,
             "locality_id":101961739,
+            "macroregion_id":1511777413,
+            "neighbourhood_id":-1,
             "region_id":85681955
         }
     ],
     "wof:id":102525967,
-    "wof:lastmodified":1566656909,
+    "wof:lastmodified":1577836750,
     "wof:name":"Lakefield Airport",
     "wof:parent_id":101961739,
     "wof:placetype":"campus",

--- a/data/102/534/495/102534495.geojson
+++ b/data/102/534/495/102534495.geojson
@@ -43,9 +43,10 @@
         "state_id":2344854
     },
     "wof:belongsto":[
-        85633009,
-        101942999,
         85681931,
+        102191577,
+        85633009,
+        1511777415,
         102052819
     ],
     "wof:breaches":[],
@@ -61,16 +62,19 @@
     "wof:hierarchy":[
         {
             "campus_id":102534495,
+            "continent_id":102191577,
             "country_id":85633009,
             "county_id":102052819,
-            "locality_id":101942999,
+            "locality_id":-1,
+            "macroregion_id":1511777415,
+            "neighbourhood_id":-1,
             "region_id":85681931
         }
     ],
     "wof:id":102534495,
-    "wof:lastmodified":1566655197,
+    "wof:lastmodified":1577841231,
     "wof:name":"Aeroporto Barra do Corda",
-    "wof:parent_id":101942999,
+    "wof:parent_id":-1,
     "wof:placetype":"campus",
     "wof:repo":"whosonfirst-data-admin-xy",
     "wof:superseded_by":[],

--- a/data/102/534/497/102534497.geojson
+++ b/data/102/534/497/102534497.geojson
@@ -49,6 +49,7 @@
         85681879,
         102191577,
         85633009,
+        1511777415,
         101966765,
         102050063
     ],
@@ -69,11 +70,13 @@
             "country_id":85633009,
             "county_id":102050063,
             "locality_id":101966765,
+            "macroregion_id":1511777415,
+            "neighbourhood_id":-1,
             "region_id":85681879
         }
     ],
     "wof:id":102534497,
-    "wof:lastmodified":1566655165,
+    "wof:lastmodified":1577841231,
     "wof:name":"Aeroporto Arapiraca",
     "wof:parent_id":101966765,
     "wof:placetype":"campus",

--- a/data/102/534/499/102534499.geojson
+++ b/data/102/534/499/102534499.geojson
@@ -32,6 +32,7 @@
         102191577,
         404559463,
         85633009,
+        1511777407,
         102055675
     ],
     "wof:breaches":[],
@@ -50,11 +51,14 @@
             "country_id":85633009,
             "county_id":102055675,
             "localadmin_id":404559463,
+            "locality_id":-1,
+            "macroregion_id":1511777407,
+            "neighbourhood_id":-1,
             "region_id":85681959
         }
     ],
     "wof:id":102534499,
-    "wof:lastmodified":1566655166,
+    "wof:lastmodified":1577826458,
     "wof:name":"Aeroporto Alenquer",
     "wof:parent_id":404559463,
     "wof:placetype":"campus",

--- a/data/102/534/501/102534501.geojson
+++ b/data/102/534/501/102534501.geojson
@@ -47,6 +47,7 @@
         102191577,
         404563069,
         85633009,
+        1511777409,
         101960351,
         102059133
     ],
@@ -68,11 +69,13 @@
             "county_id":102059133,
             "localadmin_id":404563069,
             "locality_id":101960351,
+            "macroregion_id":1511777409,
+            "neighbourhood_id":-1,
             "region_id":85682015
         }
     ],
     "wof:id":102534501,
-    "wof:lastmodified":1566655179,
+    "wof:lastmodified":1577829510,
     "wof:name":"Aeroporto Bento Goncalves",
     "wof:parent_id":101960351,
     "wof:placetype":"campus",

--- a/data/102/534/503/102534503.geojson
+++ b/data/102/534/503/102534503.geojson
@@ -50,6 +50,7 @@
         102191577,
         404554971,
         85633009,
+        1511777415,
         102052781
     ],
     "wof:breaches":[],
@@ -69,11 +70,14 @@
             "country_id":85633009,
             "county_id":102052781,
             "localadmin_id":404554971,
+            "locality_id":-1,
+            "macroregion_id":1511777415,
+            "neighbourhood_id":-1,
             "region_id":85681931
         }
     ],
     "wof:id":102534503,
-    "wof:lastmodified":1566655154,
+    "wof:lastmodified":1577841231,
     "wof:name":"Aeroporto Alto Parnaiba",
     "wof:parent_id":404554971,
     "wof:placetype":"campus",

--- a/data/102/534/509/102534509.geojson
+++ b/data/102/534/509/102534509.geojson
@@ -53,6 +53,7 @@
         85681931,
         102191577,
         85633009,
+        1511777415,
         101943087,
         102052821
     ],
@@ -73,11 +74,13 @@
             "country_id":85633009,
             "county_id":102052821,
             "locality_id":101943087,
+            "macroregion_id":1511777415,
+            "neighbourhood_id":-1,
             "region_id":85681931
         }
     ],
     "wof:id":102534509,
-    "wof:lastmodified":1566655183,
+    "wof:lastmodified":1577841232,
     "wof:name":"Aeroporto Barreirinhas",
     "wof:parent_id":101943087,
     "wof:placetype":"campus",

--- a/data/102/534/511/102534511.geojson
+++ b/data/102/534/511/102534511.geojson
@@ -81,6 +81,7 @@
         102191577,
         404567637,
         85633009,
+        1511777407,
         102062477
     ],
     "wof:breaches":[],
@@ -100,11 +101,14 @@
             "country_id":85633009,
             "county_id":102062477,
             "localadmin_id":404567637,
+            "locality_id":-1,
+            "macroregion_id":1511777407,
+            "neighbourhood_id":-1,
             "region_id":85682053
         }
     ],
     "wof:id":102534511,
-    "wof:lastmodified":1566655175,
+    "wof:lastmodified":1577826459,
     "wof:name":"Aeroporto Arraias",
     "wof:parent_id":404567637,
     "wof:placetype":"campus",

--- a/data/102/534/513/102534513.geojson
+++ b/data/102/534/513/102534513.geojson
@@ -32,6 +32,7 @@
         102191577,
         404566133,
         85633009,
+        1511777411,
         101965727,
         102061091
     ],
@@ -52,11 +53,13 @@
             "county_id":102061091,
             "localadmin_id":404566133,
             "locality_id":101965727,
+            "macroregion_id":1511777411,
+            "neighbourhood_id":-1,
             "region_id":85682041
         }
     ],
     "wof:id":102534513,
-    "wof:lastmodified":1566655202,
+    "wof:lastmodified":1577835052,
     "wof:name":"Aeroporto Aruja",
     "wof:parent_id":101965727,
     "wof:placetype":"campus",

--- a/data/102/534/515/102534515.geojson
+++ b/data/102/534/515/102534515.geojson
@@ -56,6 +56,7 @@
         102191577,
         404562907,
         85633009,
+        1511777409,
         102059049
     ],
     "wof:breaches":[],
@@ -76,11 +77,14 @@
             "country_id":85633009,
             "county_id":102059049,
             "localadmin_id":404562907,
+            "locality_id":-1,
+            "macroregion_id":1511777409,
+            "neighbourhood_id":-1,
             "region_id":85682015
         }
     ],
     "wof:id":102534515,
-    "wof:lastmodified":1566655206,
+    "wof:lastmodified":1577829510,
     "wof:name":"Aeroporto Federal",
     "wof:parent_id":404562907,
     "wof:placetype":"campus",

--- a/data/102/534/517/102534517.geojson
+++ b/data/102/534/517/102534517.geojson
@@ -74,6 +74,7 @@
         102191577,
         404559753,
         85633009,
+        1511777407,
         102055915
     ],
     "wof:breaches":[],
@@ -93,11 +94,14 @@
             "country_id":85633009,
             "county_id":102055915,
             "localadmin_id":404559753,
+            "locality_id":-1,
+            "macroregion_id":1511777407,
+            "neighbourhood_id":-1,
             "region_id":85681959
         }
     ],
     "wof:id":102534517,
-    "wof:lastmodified":1566655170,
+    "wof:lastmodified":1577826459,
     "wof:name":"Aeroporto Internacional Santarem",
     "wof:parent_id":404559753,
     "wof:placetype":"campus",

--- a/data/102/534/519/102534519.geojson
+++ b/data/102/534/519/102534519.geojson
@@ -40,6 +40,7 @@
         85682053,
         102191577,
         85633009,
+        1511777407,
         101988443,
         102062589
     ],
@@ -60,11 +61,13 @@
             "country_id":85633009,
             "county_id":102062589,
             "locality_id":101988443,
+            "macroregion_id":1511777407,
+            "neighbourhood_id":-1,
             "region_id":85682053
         }
     ],
     "wof:id":102534519,
-    "wof:lastmodified":1566655172,
+    "wof:lastmodified":1577826459,
     "wof:name":"Aeroporto Santa Isabel do Morro",
     "wof:parent_id":101988443,
     "wof:placetype":"campus",

--- a/data/102/534/521/102534521.geojson
+++ b/data/102/534/521/102534521.geojson
@@ -58,8 +58,11 @@
         "state_id":2344857
     },
     "wof:belongsto":[
+        85681959,
+        102191577,
         85633009,
-        85681959
+        1511777407,
+        102055969
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -74,14 +77,19 @@
     "wof:hierarchy":[
         {
             "campus_id":102534521,
+            "continent_id":102191577,
             "country_id":85633009,
+            "county_id":102055969,
+            "locality_id":-1,
+            "macroregion_id":1511777407,
+            "neighbourhood_id":-1,
             "region_id":85681959
         }
     ],
     "wof:id":102534521,
-    "wof:lastmodified":1566655171,
+    "wof:lastmodified":1577826459,
     "wof:name":"Aeroporto Tucurui",
-    "wof:parent_id":85681959,
+    "wof:parent_id":-1,
     "wof:placetype":"campus",
     "wof:repo":"whosonfirst-data-admin-xy",
     "wof:superseded_by":[],

--- a/data/102/534/523/102534523.geojson
+++ b/data/102/534/523/102534523.geojson
@@ -67,6 +67,7 @@
         85681885,
         102191577,
         85633009,
+        1511777407,
         101941619,
         102050417
     ],
@@ -87,11 +88,13 @@
             "country_id":85633009,
             "county_id":102050417,
             "locality_id":101941619,
+            "macroregion_id":1511777407,
+            "neighbourhood_id":-1,
             "region_id":85681885
         }
     ],
     "wof:id":102534523,
-    "wof:lastmodified":1566655205,
+    "wof:lastmodified":1577826458,
     "wof:name":"Aeroporto Tefe",
     "wof:parent_id":101941619,
     "wof:placetype":"campus",

--- a/data/102/534/531/102534531.geojson
+++ b/data/102/534/531/102534531.geojson
@@ -62,6 +62,7 @@
         85681959,
         102191577,
         85633009,
+        1511777407,
         101942195,
         102055913
     ],
@@ -82,11 +83,13 @@
             "country_id":85633009,
             "county_id":102055913,
             "locality_id":101942195,
+            "macroregion_id":1511777407,
+            "neighbourhood_id":-1,
             "region_id":85681959
         }
     ],
     "wof:id":102534531,
-    "wof:lastmodified":1566655182,
+    "wof:lastmodified":1577826458,
     "wof:name":"Aeroporto Santana do Araguaia",
     "wof:parent_id":101942195,
     "wof:placetype":"campus",

--- a/data/102/534/533/102534533.geojson
+++ b/data/102/534/533/102534533.geojson
@@ -62,6 +62,7 @@
         102191577,
         404562039,
         85633009,
+        1511777409,
         102058275
     ],
     "wof:breaches":[],
@@ -81,11 +82,14 @@
             "country_id":85633009,
             "county_id":102058275,
             "localadmin_id":404562039,
+            "locality_id":-1,
+            "macroregion_id":1511777409,
+            "neighbourhood_id":-1,
             "region_id":85681983
         }
     ],
     "wof:id":102534533,
-    "wof:lastmodified":1566655151,
+    "wof:lastmodified":1577829510,
     "wof:name":"Aeroporto Ernesto Geisel",
     "wof:parent_id":404562039,
     "wof:placetype":"campus",

--- a/data/102/534/535/102534535.geojson
+++ b/data/102/534/535/102534535.geojson
@@ -74,6 +74,7 @@
         85681983,
         102191577,
         85633009,
+        1511777409,
         101957593,
         102058243
     ],
@@ -94,11 +95,13 @@
             "country_id":85633009,
             "county_id":102058243,
             "locality_id":101957593,
+            "macroregion_id":1511777409,
+            "neighbourhood_id":-1,
             "region_id":85681983
         }
     ],
     "wof:id":102534535,
-    "wof:lastmodified":1566655155,
+    "wof:lastmodified":1577829510,
     "wof:name":"Aeroporto Telemaco Borba",
     "wof:parent_id":101957593,
     "wof:placetype":"campus",

--- a/data/102/534/539/102534539.geojson
+++ b/data/102/534/539/102534539.geojson
@@ -63,6 +63,7 @@
         102191577,
         404550289,
         85633009,
+        1511777407,
         101941549,
         102050403
     ],
@@ -85,11 +86,13 @@
             "county_id":102050403,
             "localadmin_id":404550289,
             "locality_id":101941549,
+            "macroregion_id":1511777407,
+            "neighbourhood_id":-1,
             "region_id":85681885
         }
     ],
     "wof:id":102534539,
-    "wof:lastmodified":1566655179,
+    "wof:lastmodified":1577826459,
     "wof:name":"Aeroporto Sao Gabriel da Cachoeira",
     "wof:parent_id":101941549,
     "wof:placetype":"campus",

--- a/data/102/534/545/102534545.geojson
+++ b/data/102/534/545/102534545.geojson
@@ -68,6 +68,7 @@
         102191577,
         404564491,
         85633009,
+        1511777409,
         102059875
     ],
     "wof:breaches":[],
@@ -87,11 +88,14 @@
             "country_id":85633009,
             "county_id":102059875,
             "localadmin_id":404564491,
+            "locality_id":-1,
+            "macroregion_id":1511777409,
+            "neighbourhood_id":-1,
             "region_id":85682015
         }
     ],
     "wof:id":102534545,
-    "wof:lastmodified":1566655176,
+    "wof:lastmodified":1577829510,
     "wof:name":"Aeroporto Santo Angelo",
     "wof:parent_id":404564491,
     "wof:placetype":"campus",

--- a/data/102/534/547/102534547.geojson
+++ b/data/102/534/547/102534547.geojson
@@ -59,6 +59,7 @@
         102191577,
         404558381,
         85633009,
+        1511777411,
         101952769,
         102054931
     ],
@@ -80,11 +81,13 @@
             "county_id":102054931,
             "localadmin_id":404558381,
             "locality_id":101952769,
+            "macroregion_id":1511777411,
+            "neighbourhood_id":-1,
             "region_id":85681941
         }
     ],
     "wof:id":102534547,
-    "wof:lastmodified":1566655201,
+    "wof:lastmodified":1577835052,
     "wof:name":"Aeroporto Sao Lourenco",
     "wof:parent_id":101952769,
     "wof:placetype":"campus",

--- a/data/102/534/559/102534559.geojson
+++ b/data/102/534/559/102534559.geojson
@@ -85,6 +85,7 @@
         102191577,
         404559517,
         85633009,
+        1511777407,
         101942557,
         102055703
     ],
@@ -107,11 +108,13 @@
             "county_id":102055703,
             "localadmin_id":404559517,
             "locality_id":101942557,
+            "macroregion_id":1511777407,
+            "neighbourhood_id":-1,
             "region_id":85681959
         }
     ],
     "wof:id":102534559,
-    "wof:lastmodified":1566655153,
+    "wof:lastmodified":1577826459,
     "wof:name":"Aeroporto Internacional Val de Cans",
     "wof:parent_id":101942557,
     "wof:placetype":"campus",

--- a/data/102/534/563/102534563.geojson
+++ b/data/102/534/563/102534563.geojson
@@ -62,6 +62,7 @@
         102191577,
         404564443,
         85633009,
+        1511777409,
         102059867
     ],
     "wof:breaches":[],
@@ -81,11 +82,14 @@
             "country_id":85633009,
             "county_id":102059867,
             "localadmin_id":404564443,
+            "locality_id":-1,
+            "macroregion_id":1511777409,
+            "neighbourhood_id":-1,
             "region_id":85682015
         }
     ],
     "wof:id":102534563,
-    "wof:lastmodified":1566655181,
+    "wof:lastmodified":1577829510,
     "wof:name":"Aeroporto Santa Rosa",
     "wof:parent_id":404564443,
     "wof:placetype":"campus",

--- a/data/102/534/575/102534575.geojson
+++ b/data/102/534/575/102534575.geojson
@@ -47,13 +47,13 @@
         "state_id":2344868
     },
     "wof:belongsto":[
-        85767467,
+        85682041,
         102191577,
-        404567207,
+        404566471,
         85633009,
-        101991031,
-        102062211,
-        85682041
+        1511777411,
+        101956235,
+        102061465
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -70,17 +70,18 @@
             "campus_id":102534575,
             "continent_id":102191577,
             "country_id":85633009,
-            "county_id":102062211,
-            "localadmin_id":404567207,
-            "locality_id":101991031,
-            "neighbourhood_id":85767467,
+            "county_id":102061465,
+            "localadmin_id":404566471,
+            "locality_id":101956235,
+            "macroregion_id":1511777411,
+            "neighbourhood_id":-1,
             "region_id":85682041
         }
     ],
     "wof:id":102534575,
-    "wof:lastmodified":1566655172,
+    "wof:lastmodified":1577835053,
     "wof:name":"Base a\u00e9rea de Santos",
-    "wof:parent_id":85767467,
+    "wof:parent_id":101956235,
     "wof:placetype":"campus",
     "wof:repo":"whosonfirst-data-admin-xy",
     "wof:superseded_by":[],

--- a/data/102/534/577/102534577.geojson
+++ b/data/102/534/577/102534577.geojson
@@ -60,6 +60,7 @@
         102191577,
         404567231,
         85633009,
+        1511777411,
         101964247,
         102062243
     ],
@@ -82,11 +83,13 @@
             "county_id":102062243,
             "localadmin_id":404567231,
             "locality_id":101964247,
+            "macroregion_id":1511777411,
+            "neighbourhood_id":-1,
             "region_id":85682041
         }
     ],
     "wof:id":102534577,
-    "wof:lastmodified":1566655204,
+    "wof:lastmodified":1577835052,
     "wof:name":"Aeroporto Sao Jose do Rio Preto",
     "wof:parent_id":101964247,
     "wof:placetype":"campus",

--- a/data/102/534/581/102534581.geojson
+++ b/data/102/534/581/102534581.geojson
@@ -103,6 +103,7 @@
         102191577,
         404555979,
         85633009,
+        1511777411,
         101951417,
         102053693
     ],
@@ -125,11 +126,13 @@
             "county_id":102053693,
             "localadmin_id":404555979,
             "locality_id":101951417,
+            "macroregion_id":1511777411,
+            "neighbourhood_id":-1,
             "region_id":85681941
         }
     ],
     "wof:id":102534581,
-    "wof:lastmodified":1566655172,
+    "wof:lastmodified":1577835053,
     "wof:name":"Aeroporto Internacional Tancredo Neves",
     "wof:parent_id":101951417,
     "wof:placetype":"campus",

--- a/data/102/534/587/102534587.geojson
+++ b/data/102/534/587/102534587.geojson
@@ -61,6 +61,7 @@
         85681873,
         102191577,
         85633009,
+        1511777407,
         101941519,
         102050051
     ],
@@ -81,11 +82,13 @@
             "country_id":85633009,
             "county_id":102050051,
             "locality_id":101941519,
+            "macroregion_id":1511777407,
+            "neighbourhood_id":-1,
             "region_id":85681873
         }
     ],
     "wof:id":102534587,
-    "wof:lastmodified":1566655177,
+    "wof:lastmodified":1577826460,
     "wof:name":"Aeroporto Tarauaca",
     "wof:parent_id":101941519,
     "wof:placetype":"campus",

--- a/data/102/534/591/102534591.geojson
+++ b/data/102/534/591/102534591.geojson
@@ -42,8 +42,11 @@
         "state_id":2344868
     },
     "wof:belongsto":[
+        85682041,
+        102191577,
         85633009,
-        85682041
+        1511777411,
+        102061273
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -58,14 +61,19 @@
     "wof:hierarchy":[
         {
             "campus_id":102534591,
+            "continent_id":102191577,
             "country_id":85633009,
+            "county_id":102061273,
+            "locality_id":-1,
+            "macroregion_id":1511777411,
+            "neighbourhood_id":-1,
             "region_id":85682041
         }
     ],
     "wof:id":102534591,
-    "wof:lastmodified":1566655184,
+    "wof:lastmodified":1577835053,
     "wof:name":"Aeroporto Urubupunga",
-    "wof:parent_id":85682041,
+    "wof:parent_id":-1,
     "wof:placetype":"campus",
     "wof:repo":"whosonfirst-data-admin-xy",
     "wof:superseded_by":[],

--- a/data/102/534/599/102534599.geojson
+++ b/data/102/534/599/102534599.geojson
@@ -91,6 +91,7 @@
         102191577,
         404566253,
         85633009,
+        1511777411,
         101956069,
         102061235
     ],
@@ -109,11 +110,13 @@
             "county_id":102061235,
             "localadmin_id":404566253,
             "locality_id":101956069,
+            "macroregion_id":1511777411,
+            "neighbourhood_id":-1,
             "region_id":85682041
         }
     ],
     "wof:id":102534599,
-    "wof:lastmodified":1566655180,
+    "wof:lastmodified":1577835053,
     "wof:name":"Aeroporto Internacional de Viracopos",
     "wof:parent_id":101956069,
     "wof:placetype":"campus",

--- a/data/102/534/605/102534605.geojson
+++ b/data/102/534/605/102534605.geojson
@@ -47,6 +47,7 @@
         102191577,
         404564377,
         85633009,
+        1511777409,
         101967529,
         102059853
     ],
@@ -68,11 +69,13 @@
             "county_id":102059853,
             "localadmin_id":404564377,
             "locality_id":101967529,
+            "macroregion_id":1511777409,
+            "neighbourhood_id":-1,
             "region_id":85682015
         }
     ],
     "wof:id":102534605,
-    "wof:lastmodified":1566655164,
+    "wof:lastmodified":1577829510,
     "wof:name":"Aeroporto Santa Cruz do Sul",
     "wof:parent_id":101967529,
     "wof:placetype":"campus",

--- a/data/102/534/607/102534607.geojson
+++ b/data/102/534/607/102534607.geojson
@@ -60,6 +60,7 @@
         102191577,
         404559777,
         85633009,
+        1511777407,
         101942085,
         102055929
     ],
@@ -81,11 +82,13 @@
             "county_id":102055929,
             "localadmin_id":404559777,
             "locality_id":101942085,
+            "macroregion_id":1511777407,
+            "neighbourhood_id":-1,
             "region_id":85681959
         }
     ],
     "wof:id":102534607,
-    "wof:lastmodified":1566655198,
+    "wof:lastmodified":1577826459,
     "wof:name":"Aeroporto Sao Felix do Xingu",
     "wof:parent_id":101942085,
     "wof:placetype":"campus",

--- a/data/102/534/611/102534611.geojson
+++ b/data/102/534/611/102534611.geojson
@@ -80,13 +80,13 @@
         "state_id":2344852
     },
     "wof:belongsto":[
-        85767991,
+        85681925,
         102191577,
         404554781,
         85633009,
+        1511777413,
         101968251,
-        102052205,
-        85681925
+        102052205
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -107,14 +107,15 @@
             "county_id":102052205,
             "localadmin_id":404554781,
             "locality_id":101968251,
-            "neighbourhood_id":85767991,
+            "macroregion_id":1511777413,
+            "neighbourhood_id":-1,
             "region_id":85681925
         }
     ],
     "wof:id":102534611,
-    "wof:lastmodified":1566655162,
+    "wof:lastmodified":1577836750,
     "wof:name":"Aeroporto Santa Genoveva",
-    "wof:parent_id":85767991,
+    "wof:parent_id":101968251,
     "wof:placetype":"campus",
     "wof:repo":"whosonfirst-data-admin-xy",
     "wof:superseded_by":[],

--- a/data/102/534/613/102534613.geojson
+++ b/data/102/534/613/102534613.geojson
@@ -61,8 +61,11 @@
         "state_id":2344865
     },
     "wof:belongsto":[
+        85682003,
+        102191577,
         85633009,
-        85682003
+        1511777407,
+        102058935
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -77,14 +80,19 @@
     "wof:hierarchy":[
         {
             "campus_id":102534613,
+            "continent_id":102191577,
             "country_id":85633009,
+            "county_id":102058935,
+            "locality_id":-1,
+            "macroregion_id":1511777407,
+            "neighbourhood_id":-1,
             "region_id":85682003
         }
     ],
     "wof:id":102534613,
-    "wof:lastmodified":1566655185,
+    "wof:lastmodified":1577826460,
     "wof:name":"Aeroporto Brigadeiro Camar\u00e3o",
-    "wof:parent_id":85682003,
+    "wof:parent_id":-1,
     "wof:placetype":"campus",
     "wof:repo":"whosonfirst-data-admin-xy",
     "wof:superseded_by":[],

--- a/data/102/534/635/102534635.geojson
+++ b/data/102/534/635/102534635.geojson
@@ -63,6 +63,7 @@
         102191577,
         404565983,
         85633009,
+        1511777409,
         101960567,
         102060173
     ],
@@ -84,11 +85,13 @@
             "county_id":102060173,
             "localadmin_id":404565983,
             "locality_id":101960567,
+            "macroregion_id":1511777409,
+            "neighbourhood_id":-1,
             "region_id":85682021
         }
     ],
     "wof:id":102534635,
-    "wof:lastmodified":1566655168,
+    "wof:lastmodified":1577829511,
     "wof:name":"Aeroporto Videira",
     "wof:parent_id":101960567,
     "wof:placetype":"campus",

--- a/data/102/534/637/102534637.geojson
+++ b/data/102/534/637/102534637.geojson
@@ -59,6 +59,7 @@
         102191577,
         404562001,
         85633009,
+        1511777409,
         102058257
     ],
     "wof:breaches":[],
@@ -78,11 +79,14 @@
             "country_id":85633009,
             "county_id":102058257,
             "localadmin_id":404562001,
+            "locality_id":-1,
+            "macroregion_id":1511777409,
+            "neighbourhood_id":-1,
             "region_id":85681983
         }
     ],
     "wof:id":102534637,
-    "wof:lastmodified":1566655195,
+    "wof:lastmodified":1577829511,
     "wof:name":"Aeroporto Toledo",
     "wof:parent_id":404562001,
     "wof:placetype":"campus",

--- a/data/102/534/641/102534641.geojson
+++ b/data/102/534/641/102534641.geojson
@@ -58,6 +58,7 @@
         85681925,
         102191577,
         85633009,
+        1511777413,
         101962567,
         102052099
     ],
@@ -78,11 +79,13 @@
             "country_id":85633009,
             "county_id":102052099,
             "locality_id":101962567,
+            "macroregion_id":1511777413,
+            "neighbourhood_id":-1,
             "region_id":85681925
         }
     ],
     "wof:id":102534641,
-    "wof:lastmodified":1566655191,
+    "wof:lastmodified":1577836750,
     "wof:name":"Aeroporto Caldas Novas",
     "wof:parent_id":101962567,
     "wof:placetype":"campus",

--- a/data/102/534/655/102534655.geojson
+++ b/data/102/534/655/102534655.geojson
@@ -65,6 +65,7 @@
         102191577,
         404567517,
         85633009,
+        1511777411,
         101955993,
         102062299
     ],
@@ -86,11 +87,13 @@
             "county_id":102062299,
             "localadmin_id":404567517,
             "locality_id":101955993,
+            "macroregion_id":1511777411,
+            "neighbourhood_id":-1,
             "region_id":85682041
         }
     ],
     "wof:id":102534655,
-    "wof:lastmodified":1566655193,
+    "wof:lastmodified":1577835053,
     "wof:name":"Aeroporto Sorocaba",
     "wof:parent_id":101955993,
     "wof:placetype":"campus",

--- a/data/102/534/671/102534671.geojson
+++ b/data/102/534/671/102534671.geojson
@@ -47,6 +47,7 @@
         102191577,
         404564395,
         85633009,
+        1511777409,
         101958689,
         102059855
     ],
@@ -68,11 +69,13 @@
             "county_id":102059855,
             "localadmin_id":404564395,
             "locality_id":101958689,
+            "macroregion_id":1511777409,
+            "neighbourhood_id":-1,
             "region_id":85682015
         }
     ],
     "wof:id":102534671,
-    "wof:lastmodified":1566655188,
+    "wof:lastmodified":1577829510,
     "wof:name":"Aeroporto Santa Maria",
     "wof:parent_id":101958689,
     "wof:placetype":"campus",

--- a/data/102/534/673/102534673.geojson
+++ b/data/102/534/673/102534673.geojson
@@ -50,6 +50,7 @@
         102191577,
         404554613,
         85633009,
+        1511777411,
         101969143,
         102051969
     ],
@@ -71,11 +72,13 @@
             "county_id":102051969,
             "localadmin_id":404554613,
             "locality_id":101969143,
+            "macroregion_id":1511777411,
+            "neighbourhood_id":-1,
             "region_id":85681921
         }
     ],
     "wof:id":102534673,
-    "wof:lastmodified":1566655160,
+    "wof:lastmodified":1577835053,
     "wof:name":"Aeroporto Sao Mateus",
     "wof:parent_id":101969143,
     "wof:placetype":"campus",

--- a/data/102/534/677/102534677.geojson
+++ b/data/102/534/677/102534677.geojson
@@ -50,6 +50,7 @@
         102191577,
         404553895,
         85633009,
+        1511777415,
         101945027,
         102051775
     ],
@@ -71,11 +72,13 @@
             "county_id":102051775,
             "localadmin_id":404553895,
             "locality_id":101945027,
+            "macroregion_id":1511777415,
+            "neighbourhood_id":-1,
             "region_id":85681907
         }
     ],
     "wof:id":102534677,
-    "wof:lastmodified":1566655192,
+    "wof:lastmodified":1577841232,
     "wof:name":"Aeroporto Sobral",
     "wof:parent_id":101945027,
     "wof:placetype":"campus",

--- a/data/102/534/681/102534681.geojson
+++ b/data/102/534/681/102534681.geojson
@@ -52,13 +52,13 @@
         "state_id":2344868
     },
     "wof:belongsto":[
-        85767227,
+        85682041,
         102191577,
         404567603,
         85633009,
+        1511777411,
         101956363,
-        102062389,
-        85682041
+        102062389
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -78,14 +78,15 @@
             "county_id":102062389,
             "localadmin_id":404567603,
             "locality_id":101956363,
-            "neighbourhood_id":85767227,
+            "macroregion_id":1511777411,
+            "neighbourhood_id":-1,
             "region_id":85682041
         }
     ],
     "wof:id":102534681,
-    "wof:lastmodified":1566655156,
+    "wof:lastmodified":1577835054,
     "wof:name":"Aeroporto Ubatuba",
-    "wof:parent_id":85767227,
+    "wof:parent_id":101956363,
     "wof:placetype":"campus",
     "wof:repo":"whosonfirst-data-admin-xy",
     "wof:superseded_by":[],

--- a/data/102/534/683/102534683.geojson
+++ b/data/102/534/683/102534683.geojson
@@ -77,6 +77,7 @@
         85681977,
         102191577,
         85633009,
+        1511777415,
         101943607,
         102057387
     ],
@@ -97,11 +98,13 @@
             "country_id":85633009,
             "county_id":102057387,
             "locality_id":101943607,
+            "macroregion_id":1511777415,
+            "neighbourhood_id":-1,
             "region_id":85681977
         }
     ],
     "wof:id":102534683,
-    "wof:lastmodified":1566655192,
+    "wof:lastmodified":1577841232,
     "wof:name":"Aeroporto Senador Petr\u00f4nio Portella",
     "wof:parent_id":101943607,
     "wof:placetype":"campus",

--- a/data/102/534/685/102534685.geojson
+++ b/data/102/534/685/102534685.geojson
@@ -65,6 +65,7 @@
         102191577,
         404558663,
         85633009,
+        1511777411,
         101964819,
         102055101
     ],
@@ -86,11 +87,13 @@
             "county_id":102055101,
             "localadmin_id":404558663,
             "locality_id":101964819,
+            "macroregion_id":1511777411,
+            "neighbourhood_id":-1,
             "region_id":85681941
         }
     ],
     "wof:id":102534685,
-    "wof:lastmodified":1566655187,
+    "wof:lastmodified":1577835054,
     "wof:name":"Aeroporto Uberaba",
     "wof:parent_id":101964819,
     "wof:placetype":"campus",

--- a/data/102/534/691/102534691.geojson
+++ b/data/102/534/691/102534691.geojson
@@ -52,8 +52,11 @@
         "state_id":2344847
     },
     "wof:belongsto":[
+        85681885,
+        102191577,
         85633009,
-        85681885
+        1511777407,
+        102050401
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -68,14 +71,19 @@
     "wof:hierarchy":[
         {
             "campus_id":102534691,
+            "continent_id":102191577,
             "country_id":85633009,
+            "county_id":102050401,
+            "locality_id":-1,
+            "macroregion_id":1511777407,
+            "neighbourhood_id":-1,
             "region_id":85681885
         }
     ],
     "wof:id":102534691,
-    "wof:lastmodified":1566655196,
+    "wof:lastmodified":1577826460,
     "wof:name":"Aeroporto Ipiranga",
-    "wof:parent_id":85681885,
+    "wof:parent_id":-1,
     "wof:placetype":"campus",
     "wof:repo":"whosonfirst-data-admin-xy",
     "wof:superseded_by":[],

--- a/data/102/534/693/102534693.geojson
+++ b/data/102/534/693/102534693.geojson
@@ -62,6 +62,7 @@
         102191577,
         404559469,
         85633009,
+        1511777407,
         102055677
     ],
     "wof:breaches":[],
@@ -82,11 +83,14 @@
             "country_id":85633009,
             "county_id":102055677,
             "localadmin_id":404559469,
+            "locality_id":-1,
+            "macroregion_id":1511777407,
+            "neighbourhood_id":-1,
             "region_id":85681959
         }
     ],
     "wof:id":102534693,
-    "wof:lastmodified":1566655166,
+    "wof:lastmodified":1577826458,
     "wof:name":"Aeroporto Monte Dourado",
     "wof:parent_id":404559469,
     "wof:placetype":"campus",

--- a/data/102/534/701/102534701.geojson
+++ b/data/102/534/701/102534701.geojson
@@ -43,10 +43,11 @@
         "state_id":2344855
     },
     "wof:belongsto":[
+        85681955,
         102191577,
         85633009,
-        102055555,
-        85681955
+        1511777413,
+        102055555
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -66,12 +67,13 @@
             "country_id":85633009,
             "county_id":102055555,
             "locality_id":-1,
+            "macroregion_id":1511777413,
             "neighbourhood_id":-1,
             "region_id":85681955
         }
     ],
     "wof:id":102534701,
-    "wof:lastmodified":1566655151,
+    "wof:lastmodified":1577836750,
     "wof:name":"Aeroporto Pontes E Lacerda",
     "wof:parent_id":-1,
     "wof:placetype":"campus",

--- a/data/102/534/703/102534703.geojson
+++ b/data/102/534/703/102534703.geojson
@@ -61,6 +61,7 @@
         85681959,
         102191577,
         85633009,
+        1511777407,
         101942241,
         102055885
     ],
@@ -81,11 +82,13 @@
             "country_id":85633009,
             "county_id":102055885,
             "locality_id":101942241,
+            "macroregion_id":1511777407,
+            "neighbourhood_id":-1,
             "region_id":85681959
         }
     ],
     "wof:id":102534703,
-    "wof:lastmodified":1566655182,
+    "wof:lastmodified":1577826460,
     "wof:name":"Aeroporto Redencao",
     "wof:parent_id":101942241,
     "wof:placetype":"campus",

--- a/data/102/534/709/102534709.geojson
+++ b/data/102/534/709/102534709.geojson
@@ -53,6 +53,7 @@
         102191577,
         404551785,
         85633009,
+        1511777415,
         102051165
     ],
     "wof:breaches":[],
@@ -72,11 +73,14 @@
             "country_id":85633009,
             "county_id":102051165,
             "localadmin_id":404551785,
+            "locality_id":-1,
+            "macroregion_id":1511777415,
+            "neighbourhood_id":-1,
             "region_id":85681895
         }
     ],
     "wof:id":102534709,
-    "wof:lastmodified":1566655154,
+    "wof:lastmodified":1577841232,
     "wof:name":"Aeroporto Prado",
     "wof:parent_id":404551785,
     "wof:placetype":"campus",

--- a/data/102/534/711/102534711.geojson
+++ b/data/102/534/711/102534711.geojson
@@ -32,6 +32,7 @@
         102191577,
         404557827,
         85633009,
+        1511777411,
         102054641
     ],
     "wof:breaches":[],
@@ -50,11 +51,14 @@
             "country_id":85633009,
             "county_id":102054641,
             "localadmin_id":404557827,
+            "locality_id":-1,
+            "macroregion_id":1511777411,
+            "neighbourhood_id":-1,
             "region_id":85681941
         }
     ],
     "wof:id":102534711,
-    "wof:lastmodified":1566655205,
+    "wof:lastmodified":1577835054,
     "wof:name":"Aeroporto Pirapora",
     "wof:parent_id":404557827,
     "wof:placetype":"campus",

--- a/data/102/534/713/102534713.geojson
+++ b/data/102/534/713/102534713.geojson
@@ -56,6 +56,7 @@
         102191577,
         404557575,
         85633009,
+        1511777411,
         102054507
     ],
     "wof:breaches":[],
@@ -75,11 +76,14 @@
             "country_id":85633009,
             "county_id":102054507,
             "localadmin_id":404557575,
+            "locality_id":-1,
+            "macroregion_id":1511777411,
+            "neighbourhood_id":-1,
             "region_id":85681941
         }
     ],
     "wof:id":102534713,
-    "wof:lastmodified":1566655171,
+    "wof:lastmodified":1577835054,
     "wof:name":"Aeroporto Passos",
     "wof:parent_id":404557575,
     "wof:placetype":"campus",

--- a/data/102/534/719/102534719.geojson
+++ b/data/102/534/719/102534719.geojson
@@ -41,6 +41,7 @@
         102191577,
         404559713,
         85633009,
+        1511777407,
         101942093,
         102055877
     ],
@@ -62,11 +63,13 @@
             "county_id":102055877,
             "localadmin_id":404559713,
             "locality_id":101942093,
+            "macroregion_id":1511777407,
+            "neighbourhood_id":-1,
             "region_id":85681959
         }
     ],
     "wof:id":102534719,
-    "wof:lastmodified":1566655202,
+    "wof:lastmodified":1577826459,
     "wof:name":"Aeroporto Porto de Moz",
     "wof:parent_id":101942093,
     "wof:placetype":"campus",

--- a/data/102/534/721/102534721.geojson
+++ b/data/102/534/721/102534721.geojson
@@ -65,6 +65,7 @@
         102191577,
         404567683,
         85633009,
+        1511777407,
         101942585,
         102062739
     ],
@@ -87,11 +88,13 @@
             "county_id":102062739,
             "localadmin_id":404567683,
             "locality_id":101942585,
+            "macroregion_id":1511777407,
+            "neighbourhood_id":-1,
             "region_id":85682053
         }
     ],
     "wof:id":102534721,
-    "wof:lastmodified":1566655202,
+    "wof:lastmodified":1577826461,
     "wof:name":"Aeroporto Palmas",
     "wof:parent_id":101942585,
     "wof:placetype":"campus",

--- a/data/102/534/727/102534727.geojson
+++ b/data/102/534/727/102534727.geojson
@@ -52,8 +52,11 @@
         "state_id":2344855
     },
     "wof:belongsto":[
+        85681955,
+        102191577,
         85633009,
-        85681955
+        1511777413,
+        102055479
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -68,14 +71,19 @@
     "wof:hierarchy":[
         {
             "campus_id":102534727,
+            "continent_id":102191577,
             "country_id":85633009,
+            "county_id":102055479,
+            "locality_id":-1,
+            "macroregion_id":1511777413,
+            "neighbourhood_id":-1,
             "region_id":85681955
         }
     ],
     "wof:id":102534727,
-    "wof:lastmodified":1566655205,
+    "wof:lastmodified":1577836750,
     "wof:name":"Aeroporto Juruena",
-    "wof:parent_id":85681955,
+    "wof:parent_id":-1,
     "wof:placetype":"campus",
     "wof:repo":"whosonfirst-data-admin-xy",
     "wof:superseded_by":[],

--- a/data/102/534/733/102534733.geojson
+++ b/data/102/534/733/102534733.geojson
@@ -47,6 +47,7 @@
         102191577,
         404559003,
         85633009,
+        1511777413,
         101961885,
         102055299
     ],
@@ -68,11 +69,13 @@
             "county_id":102055299,
             "localadmin_id":404559003,
             "locality_id":101961885,
+            "macroregion_id":1511777413,
+            "neighbourhood_id":-1,
             "region_id":85681947
         }
     ],
     "wof:id":102534733,
-    "wof:lastmodified":1566655179,
+    "wof:lastmodified":1577836750,
     "wof:name":"Aeroporto Paranaiba",
     "wof:parent_id":101961885,
     "wof:placetype":"campus",

--- a/data/102/534/735/102534735.geojson
+++ b/data/102/534/735/102534735.geojson
@@ -60,6 +60,7 @@
         102191577,
         404557579,
         85633009,
+        1511777411,
         102054511
     ],
     "wof:breaches":[],
@@ -79,11 +80,14 @@
             "country_id":85633009,
             "county_id":102054511,
             "localadmin_id":404557579,
+            "locality_id":-1,
+            "macroregion_id":1511777411,
+            "neighbourhood_id":-1,
             "region_id":85681941
         }
     ],
     "wof:id":102534735,
-    "wof:lastmodified":1566655182,
+    "wof:lastmodified":1577835054,
     "wof:name":"Aeroporto Patos de Minas",
     "wof:parent_id":404557579,
     "wof:placetype":"campus",

--- a/data/102/534/737/102534737.geojson
+++ b/data/102/534/737/102534737.geojson
@@ -56,6 +56,7 @@
         102191577,
         404552175,
         85633009,
+        1511777415,
         102051373
     ],
     "wof:breaches":[],
@@ -75,11 +76,14 @@
             "country_id":85633009,
             "county_id":102051373,
             "localadmin_id":404552175,
+            "locality_id":-1,
+            "macroregion_id":1511777415,
+            "neighbourhood_id":-1,
             "region_id":85681895
         }
     ],
     "wof:id":102534737,
-    "wof:lastmodified":1566655152,
+    "wof:lastmodified":1577841232,
     "wof:name":"Aeroporto Valenca",
     "wof:parent_id":404552175,
     "wof:placetype":"campus",

--- a/data/102/534/743/102534743.geojson
+++ b/data/102/534/743/102534743.geojson
@@ -47,6 +47,7 @@
         102191577,
         404564667,
         85633009,
+        1511777409,
         102059933
     ],
     "wof:breaches":[],
@@ -66,11 +67,14 @@
             "country_id":85633009,
             "county_id":102059933,
             "localadmin_id":404564667,
+            "locality_id":-1,
+            "macroregion_id":1511777409,
+            "neighbourhood_id":-1,
             "region_id":85682015
         }
     ],
     "wof:id":102534743,
-    "wof:lastmodified":1566655200,
+    "wof:lastmodified":1577829511,
     "wof:name":"Aeroporto Sao Lourenco do Sul",
     "wof:parent_id":404564667,
     "wof:placetype":"campus",

--- a/data/102/534/747/102534747.geojson
+++ b/data/102/534/747/102534747.geojson
@@ -50,6 +50,7 @@
         102191577,
         404567623,
         85633009,
+        1511777411,
         102062433
     ],
     "wof:breaches":[],
@@ -69,11 +70,14 @@
             "country_id":85633009,
             "county_id":102062433,
             "localadmin_id":404567623,
+            "locality_id":-1,
+            "macroregion_id":1511777411,
+            "neighbourhood_id":-1,
             "region_id":85682041
         }
     ],
     "wof:id":102534747,
-    "wof:lastmodified":1566655173,
+    "wof:lastmodified":1577835055,
     "wof:name":"Aeroporto Votuporanga",
     "wof:parent_id":404567623,
     "wof:placetype":"campus",

--- a/data/102/534/779/102534779.geojson
+++ b/data/102/534/779/102534779.geojson
@@ -44,6 +44,7 @@
         102191577,
         404564449,
         85633009,
+        1511777409,
         102059871
     ],
     "wof:breaches":[],
@@ -63,11 +64,14 @@
             "country_id":85633009,
             "county_id":102059871,
             "localadmin_id":404564449,
+            "locality_id":-1,
+            "macroregion_id":1511777409,
+            "neighbourhood_id":-1,
             "region_id":85682015
         }
     ],
     "wof:id":102534779,
-    "wof:lastmodified":1566655177,
+    "wof:lastmodified":1577829511,
     "wof:name":"Aeroporto do Palmar",
     "wof:parent_id":404564449,
     "wof:placetype":"campus",

--- a/data/102/534/781/102534781.geojson
+++ b/data/102/534/781/102534781.geojson
@@ -71,6 +71,7 @@
         102191577,
         404550501,
         85633009,
+        1511777415,
         101946963,
         102050537
     ],
@@ -92,11 +93,13 @@
             "county_id":102050537,
             "localadmin_id":404550501,
             "locality_id":101946963,
+            "macroregion_id":1511777415,
+            "neighbourhood_id":-1,
             "region_id":85681895
         }
     ],
     "wof:id":102534781,
-    "wof:lastmodified":1566655201,
+    "wof:lastmodified":1577841233,
     "wof:name":"Aeroporto Barra",
     "wof:parent_id":101946963,
     "wof:placetype":"campus",

--- a/data/102/534/783/102534783.geojson
+++ b/data/102/534/783/102534783.geojson
@@ -57,6 +57,7 @@
         102191577,
         404555059,
         85633009,
+        1511777415,
         102053085
     ],
     "wof:breaches":[],
@@ -76,11 +77,14 @@
             "country_id":85633009,
             "county_id":102053085,
             "localadmin_id":404555059,
+            "locality_id":-1,
+            "macroregion_id":1511777415,
+            "neighbourhood_id":-1,
             "region_id":85681931
         }
     ],
     "wof:id":102534783,
-    "wof:lastmodified":1566655176,
+    "wof:lastmodified":1577841233,
     "wof:name":"Aeroporto Pinheiro",
     "wof:parent_id":404555059,
     "wof:placetype":"campus",

--- a/data/102/534/785/102534785.geojson
+++ b/data/102/534/785/102534785.geojson
@@ -52,6 +52,7 @@
         85681955,
         102191577,
         85633009,
+        1511777413,
         101961091,
         102055435
     ],
@@ -72,11 +73,13 @@
             "country_id":85633009,
             "county_id":102055435,
             "locality_id":101961091,
+            "macroregion_id":1511777413,
+            "neighbourhood_id":-1,
             "region_id":85681955
         }
     ],
     "wof:id":102534785,
-    "wof:lastmodified":1566655173,
+    "wof:lastmodified":1577836750,
     "wof:name":"Aeroporto Diamantino",
     "wof:parent_id":101961091,
     "wof:placetype":"campus",

--- a/data/102/534/787/102534787.geojson
+++ b/data/102/534/787/102534787.geojson
@@ -59,6 +59,7 @@
         102191577,
         404554913,
         85633009,
+        1511777413,
         101961907,
         102052583
     ],
@@ -80,11 +81,13 @@
             "county_id":102052583,
             "localadmin_id":404554913,
             "locality_id":101961907,
+            "macroregion_id":1511777413,
+            "neighbourhood_id":-1,
             "region_id":85681925
         }
     ],
     "wof:id":102534787,
-    "wof:lastmodified":1566655204,
+    "wof:lastmodified":1577836751,
     "wof:name":"Aeroporto Rio Verde Gal. Castro",
     "wof:parent_id":101961907,
     "wof:placetype":"campus",

--- a/data/102/534/789/102534789.geojson
+++ b/data/102/534/789/102534789.geojson
@@ -53,6 +53,7 @@
         102191577,
         404550689,
         85633009,
+        1511777415,
         101947349,
         102050635
     ],
@@ -74,11 +75,13 @@
             "county_id":102050635,
             "localadmin_id":404550689,
             "locality_id":101947349,
+            "macroregion_id":1511777415,
+            "neighbourhood_id":-1,
             "region_id":85681895
         }
     ],
     "wof:id":102534789,
-    "wof:lastmodified":1566655204,
+    "wof:lastmodified":1577841232,
     "wof:name":"Aeroporto Canavieiras",
     "wof:parent_id":101947349,
     "wof:placetype":"campus",

--- a/data/102/534/791/102534791.geojson
+++ b/data/102/534/791/102534791.geojson
@@ -55,6 +55,7 @@
         85681955,
         102191577,
         85633009,
+        1511777413,
         101961975,
         102055611
     ],
@@ -75,11 +76,13 @@
             "country_id":85633009,
             "county_id":102055611,
             "locality_id":101961975,
+            "macroregion_id":1511777413,
+            "neighbourhood_id":-1,
             "region_id":85681955
         }
     ],
     "wof:id":102534791,
-    "wof:lastmodified":1566655153,
+    "wof:lastmodified":1577836751,
     "wof:name":"Aeroporto Santa Terezinha Confresa",
     "wof:parent_id":101961975,
     "wof:placetype":"campus",

--- a/data/102/534/793/102534793.geojson
+++ b/data/102/534/793/102534793.geojson
@@ -27,8 +27,11 @@
         "state_id":2344855
     },
     "wof:belongsto":[
+        85681955,
+        102191577,
         85633009,
-        85681955
+        1511777413,
+        102055355
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -42,14 +45,19 @@
     "wof:hierarchy":[
         {
             "campus_id":102534793,
+            "continent_id":102191577,
             "country_id":85633009,
+            "county_id":102055355,
+            "locality_id":-1,
+            "macroregion_id":1511777413,
+            "neighbourhood_id":-1,
             "region_id":85681955
         }
     ],
     "wof:id":102534793,
-    "wof:lastmodified":1566655180,
+    "wof:lastmodified":1577836751,
     "wof:name":"Aeroporto Suia-Missu",
-    "wof:parent_id":85681955,
+    "wof:parent_id":-1,
     "wof:placetype":"campus",
     "wof:repo":"whosonfirst-data-admin-xy",
     "wof:superseded_by":[],

--- a/data/102/534/801/102534801.geojson
+++ b/data/102/534/801/102534801.geojson
@@ -56,6 +56,7 @@
         102191577,
         404567671,
         85633009,
+        1511777407,
         101942497,
         102062675
     ],
@@ -77,11 +78,13 @@
             "county_id":102062675,
             "localadmin_id":404567671,
             "locality_id":101942497,
+            "macroregion_id":1511777407,
+            "neighbourhood_id":-1,
             "region_id":85682053
         }
     ],
     "wof:id":102534801,
-    "wof:lastmodified":1566655198,
+    "wof:lastmodified":1577826461,
     "wof:name":"Aeroporto Porto Nacional",
     "wof:parent_id":101942497,
     "wof:placetype":"campus",

--- a/data/102/534/803/102534803.geojson
+++ b/data/102/534/803/102534803.geojson
@@ -69,6 +69,7 @@
         102191577,
         404565553,
         85633009,
+        1511777409,
         102060493
     ],
     "wof:breaches":[],
@@ -89,11 +90,14 @@
             "country_id":85633009,
             "county_id":102060493,
             "localadmin_id":404565553,
+            "locality_id":-1,
+            "macroregion_id":1511777409,
+            "neighbourhood_id":-1,
             "region_id":85682021
         }
     ],
     "wof:id":102534803,
-    "wof:lastmodified":1566655165,
+    "wof:lastmodified":1577829512,
     "wof:name":"Aeroporto Lauro Carneiro de Loyola",
     "wof:parent_id":404565553,
     "wof:placetype":"campus",

--- a/data/102/534/807/102534807.geojson
+++ b/data/102/534/807/102534807.geojson
@@ -60,6 +60,7 @@
         102191577,
         404561671,
         85633009,
+        1511777409,
         101967985,
         102058023
     ],
@@ -81,11 +82,13 @@
             "county_id":102058023,
             "localadmin_id":404561671,
             "locality_id":101967985,
+            "macroregion_id":1511777409,
+            "neighbourhood_id":-1,
             "region_id":85681983
         }
     ],
     "wof:id":102534807,
-    "wof:lastmodified":1566655193,
+    "wof:lastmodified":1577829512,
     "wof:name":"Aeroporto Ponta Grossa",
     "wof:parent_id":101967985,
     "wof:placetype":"campus",

--- a/data/102/534/819/102534819.geojson
+++ b/data/102/534/819/102534819.geojson
@@ -56,6 +56,7 @@
         102191577,
         404561603,
         85633009,
+        1511777409,
         101963325,
         102057979
     ],
@@ -77,11 +78,13 @@
             "county_id":102057979,
             "localadmin_id":404561603,
             "locality_id":101963325,
+            "macroregion_id":1511777409,
+            "neighbourhood_id":-1,
             "region_id":85681983
         }
     ],
     "wof:id":102534819,
-    "wof:lastmodified":1566655160,
+    "wof:lastmodified":1577829512,
     "wof:name":"Aeroporto Paranavai",
     "wof:parent_id":101963325,
     "wof:placetype":"campus",

--- a/data/102/534/829/102534829.geojson
+++ b/data/102/534/829/102534829.geojson
@@ -56,6 +56,7 @@
         102191577,
         404562457,
         85633009,
+        1511777411,
         101952809,
         102058445
     ],
@@ -78,11 +79,13 @@
             "county_id":102058445,
             "localadmin_id":404562457,
             "locality_id":101952809,
+            "macroregion_id":1511777411,
+            "neighbourhood_id":-1,
             "region_id":85681991
         }
     ],
     "wof:id":102534829,
-    "wof:lastmodified":1566655157,
+    "wof:lastmodified":1577835055,
     "wof:name":"Aeroporto Resende",
     "wof:parent_id":101952809,
     "wof:placetype":"campus",

--- a/data/102/534/833/102534833.geojson
+++ b/data/102/534/833/102534833.geojson
@@ -50,6 +50,7 @@
         102191577,
         404557753,
         85633009,
+        1511777411,
         101965633,
         102054611
     ],
@@ -71,11 +72,13 @@
             "county_id":102054611,
             "localadmin_id":404557753,
             "locality_id":101965633,
+            "macroregion_id":1511777411,
+            "neighbourhood_id":-1,
             "region_id":85681941
         }
     ],
     "wof:id":102534833,
-    "wof:lastmodified":1566655168,
+    "wof:lastmodified":1577835055,
     "wof:name":"Aeroporto Embaixador Walther Moreira Salles",
     "wof:parent_id":101965633,
     "wof:placetype":"campus",

--- a/data/102/534/835/102534835.geojson
+++ b/data/102/534/835/102534835.geojson
@@ -63,6 +63,7 @@
         102191577,
         404564111,
         85633009,
+        1511777409,
         102059723
     ],
     "wof:breaches":[],
@@ -82,11 +83,14 @@
             "country_id":85633009,
             "county_id":102059723,
             "localadmin_id":404564111,
+            "locality_id":-1,
+            "macroregion_id":1511777409,
+            "neighbourhood_id":-1,
             "region_id":85682015
         }
     ],
     "wof:id":102534835,
-    "wof:lastmodified":1566655166,
+    "wof:lastmodified":1577829512,
     "wof:name":"Aeroporto Lauro Kurtz",
     "wof:parent_id":404564111,
     "wof:placetype":"campus",

--- a/data/102/534/841/102534841.geojson
+++ b/data/102/534/841/102534841.geojson
@@ -55,9 +55,10 @@
         "state_id":2344844
     },
     "wof:belongsto":[
-        85633009,
-        101941571,
         85681873,
+        102191577,
+        85633009,
+        1511777407,
         102050041
     ],
     "wof:breaches":[],
@@ -73,16 +74,19 @@
     "wof:hierarchy":[
         {
             "campus_id":102534841,
+            "continent_id":102191577,
             "country_id":85633009,
             "county_id":102050041,
-            "locality_id":101941571,
+            "locality_id":-1,
+            "macroregion_id":1511777407,
+            "neighbourhood_id":-1,
             "region_id":85681873
         }
     ],
     "wof:id":102534841,
-    "wof:lastmodified":1566655185,
+    "wof:lastmodified":1577826461,
     "wof:name":"Aeroporto Internacional Presidente M\u00e9dici",
-    "wof:parent_id":101941571,
+    "wof:parent_id":-1,
     "wof:placetype":"campus",
     "wof:repo":"whosonfirst-data-admin-xy",
     "wof:superseded_by":[],

--- a/data/102/534/845/102534845.geojson
+++ b/data/102/534/845/102534845.geojson
@@ -66,6 +66,7 @@
         102191577,
         404561465,
         85633009,
+        1511777409,
         101967655,
         102057875
     ],
@@ -88,11 +89,13 @@
             "county_id":102057875,
             "localadmin_id":404561465,
             "locality_id":101967655,
+            "macroregion_id":1511777409,
+            "neighbourhood_id":-1,
             "region_id":85681983
         }
     ],
     "wof:id":102534845,
-    "wof:lastmodified":1566655157,
+    "wof:lastmodified":1577829512,
     "wof:name":"Aeroporto Regional Silvio Name J\u00fanior",
     "wof:parent_id":101967655,
     "wof:placetype":"campus",

--- a/data/102/534/851/102534851.geojson
+++ b/data/102/534/851/102534851.geojson
@@ -82,6 +82,7 @@
         102191577,
         404559437,
         85633009,
+        1511777413,
         101961239,
         102055647
     ],
@@ -104,11 +105,13 @@
             "county_id":102055647,
             "localadmin_id":404559437,
             "locality_id":101961239,
+            "macroregion_id":1511777413,
+            "neighbourhood_id":-1,
             "region_id":85681955
         }
     ],
     "wof:id":102534851,
-    "wof:lastmodified":1566655166,
+    "wof:lastmodified":1577836751,
     "wof:name":"Aeroporto Internacional Marechal Rondon",
     "wof:parent_id":101961239,
     "wof:placetype":"campus",

--- a/data/102/534/853/102534853.geojson
+++ b/data/102/534/853/102534853.geojson
@@ -59,6 +59,7 @@
         102191577,
         404560577,
         85633009,
+        1511777415,
         102056767
     ],
     "wof:breaches":[],
@@ -78,11 +79,14 @@
             "country_id":85633009,
             "county_id":102056767,
             "localadmin_id":404560577,
+            "locality_id":-1,
+            "macroregion_id":1511777415,
+            "neighbourhood_id":-1,
             "region_id":85681973
         }
     ],
     "wof:id":102534853,
-    "wof:lastmodified":1566655196,
+    "wof:lastmodified":1577841233,
     "wof:name":"Aeroporto Senador Nilo Coelho",
     "wof:parent_id":404560577,
     "wof:placetype":"campus",

--- a/data/102/534/861/102534861.geojson
+++ b/data/102/534/861/102534861.geojson
@@ -40,6 +40,7 @@
         85681991,
         102191577,
         85633009,
+        1511777411,
         101953261,
         102058455
     ],
@@ -60,11 +61,13 @@
             "country_id":85633009,
             "county_id":102058455,
             "locality_id":101953261,
+            "macroregion_id":1511777411,
+            "neighbourhood_id":-1,
             "region_id":85681991
         }
     ],
     "wof:id":102534861,
-    "wof:lastmodified":1566655164,
+    "wof:lastmodified":1577835055,
     "wof:name":"Aeroporto Santa Cruz",
     "wof:parent_id":101953261,
     "wof:placetype":"campus",

--- a/data/102/534/863/102534863.geojson
+++ b/data/102/534/863/102534863.geojson
@@ -59,6 +59,7 @@
         102191577,
         404554857,
         85633009,
+        1511777413,
         101962615,
         102052397
     ],
@@ -80,11 +81,13 @@
             "county_id":102052397,
             "localadmin_id":404554857,
             "locality_id":101962615,
+            "macroregion_id":1511777413,
+            "neighbourhood_id":-1,
             "region_id":85681925
         }
     ],
     "wof:id":102534863,
-    "wof:lastmodified":1566655199,
+    "wof:lastmodified":1577836751,
     "wof:name":"Aeroporto Municipal de Minacu",
     "wof:parent_id":101962615,
     "wof:placetype":"campus",

--- a/data/102/534/865/102534865.geojson
+++ b/data/102/534/865/102534865.geojson
@@ -66,6 +66,7 @@
         102191577,
         404567063,
         85633009,
+        1511777411,
         101954959,
         102062035
     ],
@@ -88,11 +89,13 @@
             "county_id":102062035,
             "localadmin_id":404567063,
             "locality_id":101954959,
+            "macroregion_id":1511777411,
+            "neighbourhood_id":-1,
             "region_id":85682041
         }
     ],
     "wof:id":102534865,
-    "wof:lastmodified":1566655195,
+    "wof:lastmodified":1577835055,
     "wof:name":"Aeroporto Presidente Prudente",
     "wof:parent_id":101954959,
     "wof:placetype":"campus",

--- a/data/102/534/869/102534869.geojson
+++ b/data/102/534/869/102534869.geojson
@@ -58,6 +58,7 @@
         85681959,
         102191577,
         85633009,
+        1511777407,
         101942193,
         102055809
     ],
@@ -79,11 +80,13 @@
             "country_id":85633009,
             "county_id":102055809,
             "locality_id":101942193,
+            "macroregion_id":1511777407,
+            "neighbourhood_id":-1,
             "region_id":85681959
         }
     ],
     "wof:id":102534869,
-    "wof:lastmodified":1566655167,
+    "wof:lastmodified":1577826461,
     "wof:name":"Aeroporto Maraba",
     "wof:parent_id":101942193,
     "wof:placetype":"campus",

--- a/data/102/534/871/102534871.geojson
+++ b/data/102/534/871/102534871.geojson
@@ -65,6 +65,7 @@
         102191577,
         404550281,
         85633009,
+        1511777407,
         101942013,
         102050389
     ],
@@ -86,11 +87,13 @@
             "county_id":102050389,
             "localadmin_id":404550281,
             "locality_id":101942013,
+            "macroregion_id":1511777407,
+            "neighbourhood_id":-1,
             "region_id":85681885
         }
     ],
     "wof:id":102534871,
-    "wof:lastmodified":1566655189,
+    "wof:lastmodified":1577826460,
     "wof:name":"Aeroporto Parintins",
     "wof:parent_id":101942013,
     "wof:placetype":"campus",

--- a/data/102/534/877/102534877.geojson
+++ b/data/102/534/877/102534877.geojson
@@ -65,6 +65,7 @@
         102191577,
         404562317,
         85633009,
+        1511777411,
         101953995,
         102058385
     ],
@@ -87,11 +88,13 @@
             "county_id":102058385,
             "localadmin_id":404562317,
             "locality_id":101953995,
+            "macroregion_id":1511777411,
+            "neighbourhood_id":-1,
             "region_id":85681991
         }
     ],
     "wof:id":102534877,
-    "wof:lastmodified":1566655186,
+    "wof:lastmodified":1577835056,
     "wof:name":"Aeroporto de Maca\u00e9",
     "wof:parent_id":101953995,
     "wof:placetype":"campus",

--- a/data/102/534/883/102534883.geojson
+++ b/data/102/534/883/102534883.geojson
@@ -53,6 +53,7 @@
         102191577,
         404559685,
         85633009,
+        1511777407,
         101942065,
         102055827
     ],
@@ -74,11 +75,13 @@
             "county_id":102055827,
             "localadmin_id":404559685,
             "locality_id":101942065,
+            "macroregion_id":1511777407,
+            "neighbourhood_id":-1,
             "region_id":85681959
         }
     ],
     "wof:id":102534883,
-    "wof:lastmodified":1566655187,
+    "wof:lastmodified":1577826461,
     "wof:name":"Aeroporto Monte Alegre",
     "wof:parent_id":101942065,
     "wof:placetype":"campus",

--- a/data/102/534/887/102534887.geojson
+++ b/data/102/534/887/102534887.geojson
@@ -67,13 +67,13 @@
         "state_id":2344867
     },
     "wof:belongsto":[
-        85767449,
+        85682021,
         102191577,
         404565641,
         85633009,
+        1511777409,
         101968323,
-        102060565,
-        85682021
+        102060565
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -93,14 +93,15 @@
             "county_id":102060565,
             "localadmin_id":404565641,
             "locality_id":101968323,
-            "neighbourhood_id":85767449,
+            "macroregion_id":1511777409,
+            "neighbourhood_id":-1,
             "region_id":85682021
         }
     ],
     "wof:id":102534887,
-    "wof:lastmodified":1566655158,
+    "wof:lastmodified":1577829512,
     "wof:name":"Aeroporto Internacional Ministro Victor Konder",
-    "wof:parent_id":85767449,
+    "wof:parent_id":101968323,
     "wof:placetype":"campus",
     "wof:repo":"whosonfirst-data-admin-xy",
     "wof:superseded_by":[],

--- a/data/102/534/889/102534889.geojson
+++ b/data/102/534/889/102534889.geojson
@@ -74,6 +74,7 @@
         102191577,
         404555083,
         85633009,
+        1511777415,
         101943433,
         102053179
     ],
@@ -96,11 +97,13 @@
             "county_id":102053179,
             "localadmin_id":404555083,
             "locality_id":101943433,
+            "macroregion_id":1511777415,
+            "neighbourhood_id":-1,
             "region_id":85681931
         }
     ],
     "wof:id":102534889,
-    "wof:lastmodified":1566655158,
+    "wof:lastmodified":1577841233,
     "wof:name":"Aeroporto Internacional Marechal Cunha Machado",
     "wof:parent_id":101943433,
     "wof:placetype":"campus",

--- a/data/102/534/891/102534891.geojson
+++ b/data/102/534/891/102534891.geojson
@@ -74,6 +74,7 @@
         102191577,
         404559849,
         85633009,
+        1511777415,
         101946899,
         102056041
     ],
@@ -96,11 +97,13 @@
             "county_id":102056041,
             "localadmin_id":404559849,
             "locality_id":101946899,
+            "macroregion_id":1511777415,
+            "neighbourhood_id":-1,
             "region_id":85681967
         }
     ],
     "wof:id":102534891,
-    "wof:lastmodified":1566655195,
+    "wof:lastmodified":1577841233,
     "wof:name":"Aeroporto Internacional Presidente Castro Pinto",
     "wof:parent_id":101946899,
     "wof:placetype":"campus",

--- a/data/102/534/901/102534901.geojson
+++ b/data/102/534/901/102534901.geojson
@@ -62,6 +62,7 @@
         102191577,
         404564145,
         85633009,
+        1511777409,
         101959521,
         102059735
     ],
@@ -83,11 +84,13 @@
             "county_id":102059735,
             "localadmin_id":404564145,
             "locality_id":101959521,
+            "macroregion_id":1511777409,
+            "neighbourhood_id":-1,
             "region_id":85682015
         }
     ],
     "wof:id":102534901,
-    "wof:lastmodified":1566655153,
+    "wof:lastmodified":1577829512,
     "wof:name":"Aeroporto Pelotas",
     "wof:parent_id":101959521,
     "wof:placetype":"campus",

--- a/data/102/534/905/102534905.geojson
+++ b/data/102/534/905/102534905.geojson
@@ -58,8 +58,11 @@
         "state_id":2344861
     },
     "wof:belongsto":[
+        85681977,
+        102191577,
         85633009,
-        85681977
+        1511777415,
+        102057241
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -75,14 +78,19 @@
     "wof:hierarchy":[
         {
             "campus_id":102534905,
+            "continent_id":102191577,
             "country_id":85633009,
+            "county_id":102057241,
+            "locality_id":-1,
+            "macroregion_id":1511777415,
+            "neighbourhood_id":-1,
             "region_id":85681977
         }
     ],
     "wof:id":102534905,
-    "wof:lastmodified":1566655184,
+    "wof:lastmodified":1577841233,
     "wof:name":"Aeroporto Parnaiba",
-    "wof:parent_id":85681977,
+    "wof:parent_id":-1,
     "wof:placetype":"campus",
     "wof:repo":"whosonfirst-data-admin-xy",
     "wof:superseded_by":[],

--- a/data/102/534/907/102534907.geojson
+++ b/data/102/534/907/102534907.geojson
@@ -62,6 +62,7 @@
         102191577,
         404565547,
         85633009,
+        1511777409,
         101957245,
         102060491
     ],
@@ -83,11 +84,13 @@
             "county_id":102060491,
             "localadmin_id":404565547,
             "locality_id":101957245,
+            "macroregion_id":1511777409,
+            "neighbourhood_id":-1,
             "region_id":85682021
         }
     ],
     "wof:id":102534907,
-    "wof:lastmodified":1566655150,
+    "wof:lastmodified":1577829512,
     "wof:name":"Aeroporto Joacaba",
     "wof:parent_id":101957245,
     "wof:placetype":"campus",

--- a/data/102/534/923/102534923.geojson
+++ b/data/102/534/923/102534923.geojson
@@ -58,6 +58,7 @@
         85681991,
         102191577,
         85633009,
+        1511777411,
         101953833,
         102058313
     ],
@@ -78,11 +79,13 @@
             "country_id":85633009,
             "county_id":102058313,
             "locality_id":101953833,
+            "macroregion_id":1511777411,
+            "neighbourhood_id":-1,
             "region_id":85681991
         }
     ],
     "wof:id":102534923,
-    "wof:lastmodified":1566655174,
+    "wof:lastmodified":1577835056,
     "wof:name":"Aeroporto Buzios",
     "wof:parent_id":101953833,
     "wof:placetype":"campus",

--- a/data/102/534/925/102534925.geojson
+++ b/data/102/534/925/102534925.geojson
@@ -52,8 +52,11 @@
         "state_id":2344861
     },
     "wof:belongsto":[
+        85681977,
+        102191577,
         85633009,
-        85681977
+        1511777415,
+        102057261
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -68,14 +71,19 @@
     "wof:hierarchy":[
         {
             "campus_id":102534925,
+            "continent_id":102191577,
             "country_id":85633009,
+            "county_id":102057261,
+            "locality_id":-1,
+            "macroregion_id":1511777415,
+            "neighbourhood_id":-1,
             "region_id":85681977
         }
     ],
     "wof:id":102534925,
-    "wof:lastmodified":1566655177,
+    "wof:lastmodified":1577841233,
     "wof:name":"Aeroporto Picos",
-    "wof:parent_id":85681977,
+    "wof:parent_id":-1,
     "wof:placetype":"campus",
     "wof:repo":"whosonfirst-data-admin-xy",
     "wof:superseded_by":[],

--- a/data/102/534/929/102534929.geojson
+++ b/data/102/534/929/102534929.geojson
@@ -56,6 +56,7 @@
         102191577,
         404564249,
         85633009,
+        1511777409,
         101959799,
         102059807
     ],
@@ -77,11 +78,13 @@
             "county_id":102059807,
             "localadmin_id":404564249,
             "locality_id":101959799,
+            "macroregion_id":1511777409,
+            "neighbourhood_id":-1,
             "region_id":85682015
         }
     ],
     "wof:id":102534929,
-    "wof:lastmodified":1566655200,
+    "wof:lastmodified":1577829511,
     "wof:name":"Aeroporto Rio Grande",
     "wof:parent_id":101959799,
     "wof:placetype":"campus",

--- a/data/102/534/931/102534931.geojson
+++ b/data/102/534/931/102534931.geojson
@@ -62,6 +62,7 @@
         102191577,
         404559893,
         85633009,
+        1511777415,
         101946493,
         102056099
     ],
@@ -83,11 +84,13 @@
             "county_id":102056099,
             "localadmin_id":404559893,
             "locality_id":101946493,
+            "macroregion_id":1511777415,
+            "neighbourhood_id":-1,
             "region_id":85681967
         }
     ],
     "wof:id":102534931,
-    "wof:lastmodified":1566655150,
+    "wof:lastmodified":1577841233,
     "wof:name":"Aeroporto Presidente Jo\u00e3o Suassuna",
     "wof:parent_id":101946493,
     "wof:placetype":"campus",

--- a/data/102/534/943/102534943.geojson
+++ b/data/102/534/943/102534943.geojson
@@ -56,6 +56,7 @@
         102191577,
         404550273,
         85633009,
+        1511777407,
         101941977,
         102050377
     ],
@@ -77,11 +78,13 @@
             "county_id":102050377,
             "localadmin_id":404550273,
             "locality_id":101941977,
+            "macroregion_id":1511777407,
+            "neighbourhood_id":-1,
             "region_id":85681885
         }
     ],
     "wof:id":102534943,
-    "wof:lastmodified":1566655205,
+    "wof:lastmodified":1577826461,
     "wof:name":"Aeroporto Maues",
     "wof:parent_id":101941977,
     "wof:placetype":"campus",

--- a/data/102/534/945/102534945.geojson
+++ b/data/102/534/945/102534945.geojson
@@ -53,6 +53,7 @@
         102191577,
         404562809,
         85633009,
+        1511777407,
         101941863,
         102058921
     ],
@@ -74,11 +75,13 @@
             "county_id":102058921,
             "localadmin_id":404562809,
             "locality_id":101941863,
+            "macroregion_id":1511777407,
+            "neighbourhood_id":-1,
             "region_id":85682003
         }
     ],
     "wof:id":102534945,
-    "wof:lastmodified":1566655203,
+    "wof:lastmodified":1577826461,
     "wof:name":"Aeroporto Pimenta Bueno",
     "wof:parent_id":101941863,
     "wof:placetype":"campus",

--- a/data/102/534/951/102534951.geojson
+++ b/data/102/534/951/102534951.geojson
@@ -27,13 +27,12 @@
         "state_id":2344849
     },
     "wof:belongsto":[
-        85767361,
+        85681907,
         102191577,
         404552863,
         85633009,
         101944743,
-        102051533,
-        85681907
+        102051533
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -49,14 +48,14 @@
             "county_id":102051533,
             "localadmin_id":404552863,
             "locality_id":101944743,
-            "neighbourhood_id":85767361,
+            "neighbourhood_id":-1,
             "region_id":85681907
         }
     ],
     "wof:id":102534951,
-    "wof:lastmodified":1566655183,
+    "wof:lastmodified":1577841234,
     "wof:name":"Aeroporto Internacional Pinto Martins",
-    "wof:parent_id":85767361,
+    "wof:parent_id":101944743,
     "wof:placetype":"campus",
     "wof:repo":"whosonfirst-data-admin-xy",
     "wof:superseded_by":[],

--- a/data/102/534/953/102534953.geojson
+++ b/data/102/534/953/102534953.geojson
@@ -56,6 +56,7 @@
         102191577,
         404557807,
         85633009,
+        1511777411,
         101965845,
         102054631
     ],
@@ -77,11 +78,13 @@
             "county_id":102054631,
             "localadmin_id":404557807,
             "locality_id":101965845,
+            "macroregion_id":1511777411,
+            "neighbourhood_id":-1,
             "region_id":85681941
         }
     ],
     "wof:id":102534953,
-    "wof:lastmodified":1566655151,
+    "wof:lastmodified":1577835056,
     "wof:name":"Aeroporto Pouso Alegre",
     "wof:parent_id":101965845,
     "wof:placetype":"campus",

--- a/data/102/534/955/102534955.geojson
+++ b/data/102/534/955/102534955.geojson
@@ -52,6 +52,7 @@
         85681885,
         102191577,
         85633009,
+        1511777407,
         101941847,
         102050387
     ],
@@ -72,11 +73,13 @@
             "country_id":85633009,
             "county_id":102050387,
             "locality_id":101941847,
+            "macroregion_id":1511777407,
+            "neighbourhood_id":-1,
             "region_id":85681885
         }
     ],
     "wof:id":102534955,
-    "wof:lastmodified":1566655155,
+    "wof:lastmodified":1577826461,
     "wof:name":"Aeroporto Novo Aripuana",
     "wof:parent_id":101941847,
     "wof:placetype":"campus",

--- a/data/102/534/959/102534959.geojson
+++ b/data/102/534/959/102534959.geojson
@@ -66,12 +66,12 @@
         "state_id":2344862
     },
     "wof:belongsto":[
-        85765323,
+        85681991,
         102191577,
         85633009,
         101953261,
         102058455,
-        85681991
+        85765327
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -91,14 +91,14 @@
             "country_id":85633009,
             "county_id":102058455,
             "locality_id":101953261,
-            "neighbourhood_id":85765323,
+            "neighbourhood_id":85765327,
             "region_id":85681991
         }
     ],
     "wof:id":102534959,
-    "wof:lastmodified":1566655179,
+    "wof:lastmodified":1577835056,
     "wof:name":"Rio de Janeiro-Galeao International Airport",
-    "wof:parent_id":85765323,
+    "wof:parent_id":85765327,
     "wof:placetype":"campus",
     "wof:repo":"whosonfirst-data-admin-xy",
     "wof:superseded_by":[],

--- a/data/102/534/961/102534961.geojson
+++ b/data/102/534/961/102534961.geojson
@@ -65,6 +65,7 @@
         102191577,
         404565011,
         85633009,
+        1511777409,
         101958221,
         102060101
     ],
@@ -86,11 +87,13 @@
             "county_id":102060101,
             "localadmin_id":404565011,
             "locality_id":101958221,
+            "macroregion_id":1511777409,
+            "neighbourhood_id":-1,
             "region_id":85682015
         }
     ],
     "wof:id":102534961,
-    "wof:lastmodified":1566655179,
+    "wof:lastmodified":1577829513,
     "wof:name":"Aeroporto Internacional Rubem Berta",
     "wof:parent_id":101958221,
     "wof:placetype":"campus",

--- a/data/102/534/963/102534963.geojson
+++ b/data/102/534/963/102534963.geojson
@@ -69,6 +69,7 @@
         102191577,
         404551769,
         85633009,
+        1511777415,
         101950075,
         102051161
     ],
@@ -90,11 +91,13 @@
             "county_id":102051161,
             "localadmin_id":404551769,
             "locality_id":101950075,
+            "macroregion_id":1511777415,
+            "neighbourhood_id":-1,
             "region_id":85681895
         }
     ],
     "wof:id":102534963,
-    "wof:lastmodified":1566655154,
+    "wof:lastmodified":1577841234,
     "wof:name":"Aeroporto Porto Seguro",
     "wof:parent_id":101950075,
     "wof:placetype":"campus",

--- a/data/102/534/965/102534965.geojson
+++ b/data/102/534/965/102534965.geojson
@@ -58,6 +58,7 @@
         85682041,
         102191577,
         85633009,
+        1511777411,
         101955351,
         102061869
     ],
@@ -78,11 +79,13 @@
             "country_id":85633009,
             "county_id":102061869,
             "locality_id":101955351,
+            "macroregion_id":1511777411,
+            "neighbourhood_id":-1,
             "region_id":85682041
         }
     ],
     "wof:id":102534965,
-    "wof:lastmodified":1566655152,
+    "wof:lastmodified":1577835055,
     "wof:name":"Aeroporto Ourinhos",
     "wof:parent_id":101955351,
     "wof:placetype":"campus",

--- a/data/102/534/971/102534971.geojson
+++ b/data/102/534/971/102534971.geojson
@@ -58,8 +58,11 @@
         "state_id":2344857
     },
     "wof:belongsto":[
+        85681959,
+        102191577,
         85633009,
-        85681959
+        1511777407,
+        102055847
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -74,14 +77,19 @@
     "wof:hierarchy":[
         {
             "campus_id":102534971,
+            "continent_id":102191577,
             "country_id":85633009,
+            "county_id":102055847,
+            "locality_id":-1,
+            "macroregion_id":1511777407,
+            "neighbourhood_id":-1,
             "region_id":85681959
         }
     ],
     "wof:id":102534971,
-    "wof:lastmodified":1566655175,
+    "wof:lastmodified":1577826462,
     "wof:name":"Aeroporto Oriximina",
-    "wof:parent_id":85681959,
+    "wof:parent_id":-1,
     "wof:placetype":"campus",
     "wof:repo":"whosonfirst-data-admin-xy",
     "wof:superseded_by":[],

--- a/data/102/534/973/102534973.geojson
+++ b/data/102/534/973/102534973.geojson
@@ -68,6 +68,7 @@
         102191577,
         404551697,
         85633009,
+        1511777415,
         101950495,
         102051123
     ],
@@ -89,11 +90,13 @@
             "county_id":102051123,
             "localadmin_id":404551697,
             "locality_id":101950495,
+            "macroregion_id":1511777415,
+            "neighbourhood_id":-1,
             "region_id":85681895
         }
     ],
     "wof:id":102534973,
-    "wof:lastmodified":1566655202,
+    "wof:lastmodified":1577841234,
     "wof:name":"Aeroporto Paulo Afonso",
     "wof:parent_id":101950495,
     "wof:placetype":"campus",

--- a/data/102/534/983/102534983.geojson
+++ b/data/102/534/983/102534983.geojson
@@ -50,8 +50,10 @@
     },
     "wof:belongsto":[
         85681885,
+        102191577,
         85633009,
-        85765151,
+        1511777407,
+        101941913,
         102050371
     ],
     "wof:breaches":[],
@@ -67,16 +69,19 @@
     "wof:hierarchy":[
         {
             "campus_id":102534983,
+            "continent_id":102191577,
             "country_id":85633009,
             "county_id":102050371,
-            "neighbourhood_id":85765151,
+            "locality_id":101941913,
+            "macroregion_id":1511777407,
+            "neighbourhood_id":-1,
             "region_id":85681885
         }
     ],
     "wof:id":102534983,
-    "wof:lastmodified":1566655170,
+    "wof:lastmodified":1577826462,
     "wof:name":"Aeroporto Ponta Pelada",
-    "wof:parent_id":85765151,
+    "wof:parent_id":101941913,
     "wof:placetype":"campus",
     "wof:repo":"whosonfirst-data-admin-xy",
     "wof:superseded_by":[],

--- a/data/102/534/985/102534985.geojson
+++ b/data/102/534/985/102534985.geojson
@@ -74,6 +74,7 @@
         102191577,
         404567119,
         85633009,
+        1511777411,
         101964909,
         102062087
     ],
@@ -95,11 +96,13 @@
             "county_id":102062087,
             "localadmin_id":404567119,
             "locality_id":101964909,
+            "macroregion_id":1511777411,
+            "neighbourhood_id":-1,
             "region_id":85682041
         }
     ],
     "wof:id":102534985,
-    "wof:lastmodified":1566655175,
+    "wof:lastmodified":1577835056,
     "wof:name":"Aeroporto Leite Lopes",
     "wof:parent_id":101964909,
     "wof:placetype":"campus",

--- a/data/102/534/987/102534987.geojson
+++ b/data/102/534/987/102534987.geojson
@@ -50,6 +50,7 @@
         102191577,
         404550341,
         85633009,
+        1511777407,
         101942097,
         102050449
     ],
@@ -71,11 +72,13 @@
             "county_id":102050449,
             "localadmin_id":404550341,
             "locality_id":101942097,
+            "macroregion_id":1511777407,
+            "neighbourhood_id":-1,
             "region_id":85681891
         }
     ],
     "wof:id":102534987,
-    "wof:lastmodified":1566655201,
+    "wof:lastmodified":1577826462,
     "wof:name":"Aeroporto Oiapoque",
     "wof:parent_id":101942097,
     "wof:placetype":"campus",

--- a/data/102/534/989/102534989.geojson
+++ b/data/102/534/989/102534989.geojson
@@ -68,6 +68,7 @@
         102191577,
         404562813,
         85633009,
+        1511777407,
         101941621,
         102058923
     ],
@@ -90,11 +91,13 @@
             "county_id":102058923,
             "localadmin_id":404562813,
             "locality_id":101941621,
+            "macroregion_id":1511777407,
+            "neighbourhood_id":-1,
             "region_id":85682003
         }
     ],
     "wof:id":102534989,
-    "wof:lastmodified":1566655202,
+    "wof:lastmodified":1577826462,
     "wof:name":"Aeroporto Internacional Governador Jorge Teixeira de Oliveira",
     "wof:parent_id":101941621,
     "wof:placetype":"campus",

--- a/data/102/534/991/102534991.geojson
+++ b/data/102/534/991/102534991.geojson
@@ -56,6 +56,7 @@
         102191577,
         404561613,
         85633009,
+        1511777409,
         101956899,
         102057983
     ],
@@ -77,11 +78,13 @@
             "county_id":102057983,
             "localadmin_id":404561613,
             "locality_id":101956899,
+            "macroregion_id":1511777409,
+            "neighbourhood_id":-1,
             "region_id":85681983
         }
     ],
     "wof:id":102534991,
-    "wof:lastmodified":1566655152,
+    "wof:lastmodified":1577829513,
     "wof:name":"Aeroporto Municipal de Pato Branco",
     "wof:parent_id":101956899,
     "wof:placetype":"campus",

--- a/data/102/535/001/102535001.geojson
+++ b/data/102/535/001/102535001.geojson
@@ -53,6 +53,7 @@
         102191577,
         404561597,
         85633009,
+        1511777409,
         101958167,
         102057973
     ],
@@ -74,11 +75,13 @@
             "county_id":102057973,
             "localadmin_id":404561597,
             "locality_id":101958167,
+            "macroregion_id":1511777409,
+            "neighbourhood_id":-1,
             "region_id":85681983
         }
     ],
     "wof:id":102535001,
-    "wof:lastmodified":1566655365,
+    "wof:lastmodified":1577829507,
     "wof:name":"Aeroporto Municipal de Paranagua",
     "wof:parent_id":101958167,
     "wof:placetype":"campus",

--- a/data/102/535/013/102535013.geojson
+++ b/data/102/535/013/102535013.geojson
@@ -73,13 +73,13 @@
         "state_id":2344856
     },
     "wof:belongsto":[
-        85766593,
+        85681941,
         102191577,
         404555403,
         85633009,
+        1511777411,
         101948979,
-        102053515,
-        85681941
+        102053515
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -100,14 +100,15 @@
             "county_id":102053515,
             "localadmin_id":404555403,
             "locality_id":101948979,
-            "neighbourhood_id":85766593,
+            "macroregion_id":1511777411,
+            "neighbourhood_id":-1,
             "region_id":85681941
         }
     ],
     "wof:id":102535013,
-    "wof:lastmodified":1566655355,
+    "wof:lastmodified":1577835050,
     "wof:name":"Aeroporto da Pampulha",
-    "wof:parent_id":85766593,
+    "wof:parent_id":101948979,
     "wof:placetype":"campus",
     "wof:repo":"whosonfirst-data-admin-xy",
     "wof:superseded_by":[],

--- a/data/102/535/015/102535015.geojson
+++ b/data/102/535/015/102535015.geojson
@@ -62,6 +62,7 @@
         102191577,
         404559017,
         85633009,
+        1511777413,
         101961275,
         102055305
     ],
@@ -83,11 +84,13 @@
             "county_id":102055305,
             "localadmin_id":404559017,
             "locality_id":101961275,
+            "macroregion_id":1511777413,
+            "neighbourhood_id":-1,
             "region_id":85681947
         }
     ],
     "wof:id":102535015,
-    "wof:lastmodified":1566655352,
+    "wof:lastmodified":1577836748,
     "wof:name":"Aeroporto Internacional Ponta Pora",
     "wof:parent_id":101961275,
     "wof:placetype":"campus",

--- a/data/102/535/017/102535017.geojson
+++ b/data/102/535/017/102535017.geojson
@@ -57,6 +57,7 @@
         102191577,
         404550271,
         85633009,
+        1511777407,
         101941755,
         102050373
     ],
@@ -78,11 +79,13 @@
             "county_id":102050373,
             "localadmin_id":404550271,
             "locality_id":101941755,
+            "macroregion_id":1511777407,
+            "neighbourhood_id":-1,
             "region_id":85681885
         }
     ],
     "wof:id":102535017,
-    "wof:lastmodified":1566655388,
+    "wof:lastmodified":1577826456,
     "wof:name":"Aeroporto Manicore",
     "wof:parent_id":101941755,
     "wof:placetype":"campus",

--- a/data/102/535/019/102535019.geojson
+++ b/data/102/535/019/102535019.geojson
@@ -65,6 +65,7 @@
         102191577,
         404559357,
         85633009,
+        1511777413,
         101961465,
         102055601
     ],
@@ -86,11 +87,13 @@
             "county_id":102055601,
             "localadmin_id":404559357,
             "locality_id":101961465,
+            "macroregion_id":1511777413,
+            "neighbourhood_id":-1,
             "region_id":85681955
         }
     ],
     "wof:id":102535019,
-    "wof:lastmodified":1566655390,
+    "wof:lastmodified":1577836748,
     "wof:name":"Aeroporto Rondonopolis",
     "wof:parent_id":101961465,
     "wof:placetype":"campus",

--- a/data/102/535/023/102535023.geojson
+++ b/data/102/535/023/102535023.geojson
@@ -46,9 +46,10 @@
         "state_id":2344870
     },
     "wof:belongsto":[
-        85633009,
-        101942873,
         85682053,
+        102191577,
+        85633009,
+        1511777407,
         102062541
     ],
     "wof:breaches":[],
@@ -64,16 +65,19 @@
     "wof:hierarchy":[
         {
             "campus_id":102535023,
+            "continent_id":102191577,
             "country_id":85633009,
             "county_id":102062541,
-            "locality_id":101942873,
+            "locality_id":-1,
+            "macroregion_id":1511777407,
+            "neighbourhood_id":-1,
             "region_id":85682053
         }
     ],
     "wof:id":102535023,
-    "wof:lastmodified":1566655351,
+    "wof:lastmodified":1577826456,
     "wof:name":"Aeroporto Dianopolis",
-    "wof:parent_id":101942873,
+    "wof:parent_id":-1,
     "wof:placetype":"campus",
     "wof:repo":"whosonfirst-data-admin-xy",
     "wof:superseded_by":[],

--- a/data/102/535/027/102535027.geojson
+++ b/data/102/535/027/102535027.geojson
@@ -66,6 +66,7 @@
         102191577,
         404560273,
         85633009,
+        1511777415,
         102056585
     ],
     "wof:breaches":[],
@@ -85,11 +86,14 @@
             "country_id":85633009,
             "county_id":102056585,
             "localadmin_id":404560273,
+            "locality_id":-1,
+            "macroregion_id":1511777415,
+            "neighbourhood_id":-1,
             "region_id":85681973
         }
     ],
     "wof:id":102535027,
-    "wof:lastmodified":1566655385,
+    "wof:lastmodified":1577841229,
     "wof:name":"Aeroporto Caruaru",
     "wof:parent_id":404560273,
     "wof:placetype":"campus",

--- a/data/102/535/031/102535031.geojson
+++ b/data/102/535/031/102535031.geojson
@@ -53,6 +53,7 @@
         102191577,
         404565221,
         85633009,
+        1511777409,
         101958053,
         102060269
     ],
@@ -74,11 +75,13 @@
             "county_id":102060269,
             "localadmin_id":404565221,
             "locality_id":101958053,
+            "macroregion_id":1511777409,
+            "neighbourhood_id":-1,
             "region_id":85682021
         }
     ],
     "wof:id":102535031,
-    "wof:lastmodified":1566655362,
+    "wof:lastmodified":1577829508,
     "wof:name":"Aeroporto Blumenau",
     "wof:parent_id":101958053,
     "wof:placetype":"campus",

--- a/data/102/535/033/102535033.geojson
+++ b/data/102/535/033/102535033.geojson
@@ -65,6 +65,7 @@
         85681885,
         102191577,
         85633009,
+        1511777407,
         101941589,
         102050323
     ],
@@ -85,11 +86,13 @@
             "country_id":85633009,
             "county_id":102050323,
             "locality_id":101941589,
+            "macroregion_id":1511777407,
+            "neighbourhood_id":-1,
             "region_id":85681885
         }
     ],
     "wof:id":102535033,
-    "wof:lastmodified":1566655396,
+    "wof:lastmodified":1577826457,
     "wof:name":"Aeroporto Carauari",
     "wof:parent_id":101941589,
     "wof:placetype":"campus",

--- a/data/102/535/035/102535035.geojson
+++ b/data/102/535/035/102535035.geojson
@@ -52,6 +52,7 @@
         85681931,
         102191577,
         85633009,
+        1511777415,
         101942917,
         102052815
     ],
@@ -72,11 +73,13 @@
             "country_id":85633009,
             "county_id":102052815,
             "locality_id":101942917,
+            "macroregion_id":1511777415,
+            "neighbourhood_id":-1,
             "region_id":85681931
         }
     ],
     "wof:id":102535035,
-    "wof:lastmodified":1566655393,
+    "wof:lastmodified":1577841229,
     "wof:name":"Aeroporto Balsas",
     "wof:parent_id":101942917,
     "wof:placetype":"campus",

--- a/data/102/535/037/102535037.geojson
+++ b/data/102/535/037/102535037.geojson
@@ -69,6 +69,7 @@
         102191577,
         404562173,
         85633009,
+        1511777411,
         101953927,
         102058341
     ],
@@ -91,11 +92,13 @@
             "county_id":102058341,
             "localadmin_id":404562173,
             "locality_id":101953927,
+            "macroregion_id":1511777411,
+            "neighbourhood_id":-1,
             "region_id":85681991
         }
     ],
     "wof:id":102535037,
-    "wof:lastmodified":1566655365,
+    "wof:lastmodified":1577835050,
     "wof:name":"Aeroporto Bartolomeu Lisandro",
     "wof:parent_id":101953927,
     "wof:placetype":"campus",

--- a/data/102/535/039/102535039.geojson
+++ b/data/102/535/039/102535039.geojson
@@ -66,6 +66,7 @@
         85681999,
         102191577,
         85633009,
+        1511777415,
         101946845,
         102058709
     ],
@@ -87,11 +88,13 @@
             "country_id":85633009,
             "county_id":102058709,
             "locality_id":101946845,
+            "macroregion_id":1511777415,
+            "neighbourhood_id":-1,
             "region_id":85681999
         }
     ],
     "wof:id":102535039,
-    "wof:lastmodified":1566655366,
+    "wof:lastmodified":1577841229,
     "wof:name":"Aeroporto Internacional Augusto Severo",
     "wof:parent_id":101946845,
     "wof:placetype":"campus",

--- a/data/102/535/041/102535041.geojson
+++ b/data/102/535/041/102535041.geojson
@@ -53,6 +53,7 @@
         102191577,
         404559553,
         85633009,
+        1511777407,
         102055723
     ],
     "wof:breaches":[],
@@ -72,11 +73,14 @@
             "country_id":85633009,
             "county_id":102055723,
             "localadmin_id":404559553,
+            "locality_id":-1,
+            "macroregion_id":1511777407,
+            "neighbourhood_id":-1,
             "region_id":85681959
         }
     ],
     "wof:id":102535041,
-    "wof:lastmodified":1566655353,
+    "wof:lastmodified":1577826457,
     "wof:name":"Aeroporto Breves",
     "wof:parent_id":404559553,
     "wof:placetype":"campus",

--- a/data/102/535/043/102535043.geojson
+++ b/data/102/535/043/102535043.geojson
@@ -69,6 +69,7 @@
         102191577,
         404560875,
         85633009,
+        1511777409,
         102057443
     ],
     "wof:breaches":[],
@@ -88,11 +89,14 @@
             "country_id":85633009,
             "county_id":102057443,
             "localadmin_id":404560875,
+            "locality_id":-1,
+            "macroregion_id":1511777409,
+            "neighbourhood_id":-1,
             "region_id":85681983
         }
     ],
     "wof:id":102535043,
-    "wof:lastmodified":1566655388,
+    "wof:lastmodified":1577829508,
     "wof:name":"Aeroporto Apucarana",
     "wof:parent_id":404560875,
     "wof:placetype":"campus",

--- a/data/102/535/053/102535053.geojson
+++ b/data/102/535/053/102535053.geojson
@@ -49,6 +49,7 @@
         85682015,
         102191577,
         85633009,
+        1511777409,
         101960519,
         102059215
     ],
@@ -69,11 +70,13 @@
             "country_id":85633009,
             "county_id":102059215,
             "locality_id":101960519,
+            "macroregion_id":1511777409,
+            "neighbourhood_id":-1,
             "region_id":85682015
         }
     ],
     "wof:id":102535053,
-    "wof:lastmodified":1566655360,
+    "wof:lastmodified":1577829507,
     "wof:name":"Aeroporto Canoas",
     "wof:parent_id":101960519,
     "wof:placetype":"campus",

--- a/data/102/535/059/102535059.geojson
+++ b/data/102/535/059/102535059.geojson
@@ -97,6 +97,7 @@
         102191577,
         404561911,
         85633009,
+        1511777409,
         101958005,
         102058193
     ],
@@ -119,11 +120,13 @@
             "county_id":102058193,
             "localadmin_id":404561911,
             "locality_id":101958005,
+            "macroregion_id":1511777409,
+            "neighbourhood_id":-1,
             "region_id":85681983
         }
     ],
     "wof:id":102535059,
-    "wof:lastmodified":1566655394,
+    "wof:lastmodified":1577829507,
     "wof:name":"Aeroporto Internacional Afonso Pena",
     "wof:parent_id":101958005,
     "wof:placetype":"campus",

--- a/data/102/535/063/102535063.geojson
+++ b/data/102/535/063/102535063.geojson
@@ -69,6 +69,7 @@
         102191577,
         404560877,
         85633009,
+        1511777409,
         101954947,
         102057445
     ],
@@ -90,11 +91,13 @@
             "county_id":102057445,
             "localadmin_id":404560877,
             "locality_id":101954947,
+            "macroregion_id":1511777409,
+            "neighbourhood_id":-1,
             "region_id":85681983
         }
     ],
     "wof:id":102535063,
-    "wof:lastmodified":1566655364,
+    "wof:lastmodified":1577829508,
     "wof:name":"Aeroporto Arapongas",
     "wof:parent_id":101954947,
     "wof:placetype":"campus",

--- a/data/102/535/067/102535067.geojson
+++ b/data/102/535/067/102535067.geojson
@@ -53,6 +53,7 @@
         102191577,
         404555183,
         85633009,
+        1511777411,
         102053407
     ],
     "wof:breaches":[],
@@ -72,11 +73,14 @@
             "country_id":85633009,
             "county_id":102053407,
             "localadmin_id":404555183,
+            "locality_id":-1,
+            "macroregion_id":1511777411,
+            "neighbourhood_id":-1,
             "region_id":85681941
         }
     ],
     "wof:id":102535067,
-    "wof:lastmodified":1566655399,
+    "wof:lastmodified":1577835050,
     "wof:name":"Aeroporto Almenara",
     "wof:parent_id":404555183,
     "wof:placetype":"campus",

--- a/data/102/535/069/102535069.geojson
+++ b/data/102/535/069/102535069.geojson
@@ -37,9 +37,10 @@
         "state_id":2344855
     },
     "wof:belongsto":[
-        85633009,
-        101961817,
         85681925,
+        102191577,
+        85633009,
+        1511777413,
         102052043
     ],
     "wof:breaches":[],
@@ -55,16 +56,19 @@
     "wof:hierarchy":[
         {
             "campus_id":102535069,
+            "continent_id":102191577,
             "country_id":85633009,
             "county_id":102052043,
-            "locality_id":101961817,
+            "locality_id":-1,
+            "macroregion_id":1511777413,
+            "neighbourhood_id":-1,
             "region_id":85681925
         }
     ],
     "wof:id":102535069,
-    "wof:lastmodified":1566655397,
+    "wof:lastmodified":1577836749,
     "wof:name":"Aeroporto Aragarcas",
-    "wof:parent_id":101961817,
+    "wof:parent_id":-1,
     "wof:placetype":"campus",
     "wof:repo":"whosonfirst-data-admin-xy",
     "wof:superseded_by":[],

--- a/data/102/535/073/102535073.geojson
+++ b/data/102/535/073/102535073.geojson
@@ -56,8 +56,11 @@
         "state_id":2344857
     },
     "wof:belongsto":[
+        85681959,
+        102191577,
         85633009,
-        85681959
+        1511777407,
+        102055749
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -72,14 +75,19 @@
     "wof:hierarchy":[
         {
             "campus_id":102535073,
+            "continent_id":102191577,
             "country_id":85633009,
+            "county_id":102055749,
+            "locality_id":-1,
+            "macroregion_id":1511777407,
+            "neighbourhood_id":-1,
             "region_id":85681959
         }
     ],
     "wof:id":102535073,
-    "wof:lastmodified":1566655383,
+    "wof:lastmodified":1577826457,
     "wof:name":"Aeroporto Conceicao do Araguaia",
-    "wof:parent_id":85681959,
+    "wof:parent_id":-1,
     "wof:placetype":"campus",
     "wof:repo":"whosonfirst-data-admin-xy",
     "wof:superseded_by":[],

--- a/data/102/535/075/102535075.geojson
+++ b/data/102/535/075/102535075.geojson
@@ -38,6 +38,7 @@
         102191577,
         404554705,
         85633009,
+        1511777413,
         101962511,
         102052027
     ],
@@ -60,11 +61,13 @@
             "county_id":102052027,
             "localadmin_id":404554705,
             "locality_id":101962511,
+            "macroregion_id":1511777413,
+            "neighbourhood_id":-1,
             "region_id":85681925
         }
     ],
     "wof:id":102535075,
-    "wof:lastmodified":1566655386,
+    "wof:lastmodified":1577836749,
     "wof:name":"Aeroporto Anapolis",
     "wof:parent_id":101962511,
     "wof:placetype":"campus",

--- a/data/102/535/087/102535087.geojson
+++ b/data/102/535/087/102535087.geojson
@@ -69,6 +69,7 @@
         102191577,
         404566117,
         85633009,
+        1511777411,
         102061059
     ],
     "wof:breaches":[],
@@ -89,11 +90,14 @@
             "country_id":85633009,
             "county_id":102061059,
             "localadmin_id":404566117,
+            "locality_id":-1,
+            "macroregion_id":1511777411,
+            "neighbourhood_id":-1,
             "region_id":85682041
         }
     ],
     "wof:id":102535087,
-    "wof:lastmodified":1566655383,
+    "wof:lastmodified":1577835051,
     "wof:name":"Aeroporto Aracatuba",
     "wof:parent_id":404566117,
     "wof:placetype":"campus",

--- a/data/102/535/091/102535091.geojson
+++ b/data/102/535/091/102535091.geojson
@@ -77,6 +77,7 @@
         85681955,
         102191577,
         85633009,
+        1511777413,
         101961141,
         102055351
     ],
@@ -97,11 +98,13 @@
             "country_id":85633009,
             "county_id":102055351,
             "locality_id":101961141,
+            "macroregion_id":1511777413,
+            "neighbourhood_id":-1,
             "region_id":85681955
         }
     ],
     "wof:id":102535091,
-    "wof:lastmodified":1566655359,
+    "wof:lastmodified":1577836749,
     "wof:name":"Aeroporto Alta Floresta",
     "wof:parent_id":101961141,
     "wof:placetype":"campus",

--- a/data/102/535/105/102535105.geojson
+++ b/data/102/535/105/102535105.geojson
@@ -88,6 +88,7 @@
         102191577,
         404561161,
         85633009,
+        1511777409,
         102057673
     ],
     "wof:breaches":[],
@@ -108,11 +109,14 @@
             "country_id":85633009,
             "county_id":102057673,
             "localadmin_id":404561161,
+            "locality_id":-1,
+            "macroregion_id":1511777409,
+            "neighbourhood_id":-1,
             "region_id":85681983
         }
     ],
     "wof:id":102535105,
-    "wof:lastmodified":1566655347,
+    "wof:lastmodified":1577829508,
     "wof:name":"Aeroporto Internacional Cataratas",
     "wof:parent_id":404561161,
     "wof:placetype":"campus",

--- a/data/102/535/113/102535113.geojson
+++ b/data/102/535/113/102535113.geojson
@@ -52,6 +52,7 @@
         85682015,
         102191577,
         85633009,
+        1511777409,
         101960691,
         102059211
     ],
@@ -72,11 +73,13 @@
             "country_id":85633009,
             "county_id":102059211,
             "locality_id":101960691,
+            "macroregion_id":1511777409,
+            "neighbourhood_id":-1,
             "region_id":85682015
         }
     ],
     "wof:id":102535113,
-    "wof:lastmodified":1566655407,
+    "wof:lastmodified":1577829508,
     "wof:name":"Aeroporto Canela",
     "wof:parent_id":101960691,
     "wof:placetype":"campus",

--- a/data/102/535/117/102535117.geojson
+++ b/data/102/535/117/102535117.geojson
@@ -50,6 +50,7 @@
         102191577,
         404559127,
         85633009,
+        1511777413,
         101961007,
         102055389
     ],
@@ -71,11 +72,13 @@
             "county_id":102055389,
             "localadmin_id":404559127,
             "locality_id":101961007,
+            "macroregion_id":1511777413,
+            "neighbourhood_id":-1,
             "region_id":85681955
         }
     ],
     "wof:id":102535117,
-    "wof:lastmodified":1566655373,
+    "wof:lastmodified":1577836749,
     "wof:name":"Aeroporto Caceres",
     "wof:parent_id":101961007,
     "wof:placetype":"campus",

--- a/data/102/535/121/102535121.geojson
+++ b/data/102/535/121/102535121.geojson
@@ -71,6 +71,7 @@
         102191577,
         404565317,
         85633009,
+        1511777409,
         102060337
     ],
     "wof:breaches":[],
@@ -91,11 +92,14 @@
             "country_id":85633009,
             "county_id":102060337,
             "localadmin_id":404565317,
+            "locality_id":-1,
+            "macroregion_id":1511777409,
+            "neighbourhood_id":-1,
             "region_id":85682021
         }
     ],
     "wof:id":102535121,
-    "wof:lastmodified":1566655372,
+    "wof:lastmodified":1577829508,
     "wof:name":"Aeroporto Chapeco",
     "wof:parent_id":404565317,
     "wof:placetype":"campus",

--- a/data/102/535/125/102535125.geojson
+++ b/data/102/535/125/102535125.geojson
@@ -69,6 +69,7 @@
         102191577,
         404559471,
         85633009,
+        1511777407,
         101942051,
         102055679
     ],
@@ -90,11 +91,13 @@
             "county_id":102055679,
             "localadmin_id":404559471,
             "locality_id":101942051,
+            "macroregion_id":1511777407,
+            "neighbourhood_id":-1,
             "region_id":85681959
         }
     ],
     "wof:id":102535125,
-    "wof:lastmodified":1566655405,
+    "wof:lastmodified":1577826457,
     "wof:name":"Aeroporto Altamira",
     "wof:parent_id":101942051,
     "wof:placetype":"campus",

--- a/data/102/535/135/102535135.geojson
+++ b/data/102/535/135/102535135.geojson
@@ -65,6 +65,7 @@
         102191577,
         404565331,
         85633009,
+        1511777409,
         102060341
     ],
     "wof:breaches":[],
@@ -84,11 +85,14 @@
             "country_id":85633009,
             "county_id":102060341,
             "localadmin_id":404565331,
+            "locality_id":-1,
+            "macroregion_id":1511777409,
+            "neighbourhood_id":-1,
             "region_id":85682021
         }
     ],
     "wof:id":102535135,
-    "wof:lastmodified":1566655342,
+    "wof:lastmodified":1577829508,
     "wof:name":"Aeroporto Concordia",
     "wof:parent_id":404565331,
     "wof:placetype":"campus",

--- a/data/102/535/139/102535139.geojson
+++ b/data/102/535/139/102535139.geojson
@@ -61,6 +61,7 @@
         85681885,
         102191577,
         85633009,
+        1511777407,
         101941633,
         102050331
     ],
@@ -81,11 +82,13 @@
             "country_id":85633009,
             "county_id":102050331,
             "locality_id":101941633,
+            "macroregion_id":1511777407,
+            "neighbourhood_id":-1,
             "region_id":85681885
         }
     ],
     "wof:id":102535139,
-    "wof:lastmodified":1566655379,
+    "wof:lastmodified":1577826457,
     "wof:name":"Aeroporto Coari",
     "wof:parent_id":101941633,
     "wof:placetype":"campus",

--- a/data/102/535/145/102535145.geojson
+++ b/data/102/535/145/102535145.geojson
@@ -67,6 +67,7 @@
         85682053,
         102191577,
         85633009,
+        1511777407,
         101942407,
         102062467
     ],
@@ -87,11 +88,13 @@
             "country_id":85633009,
             "county_id":102062467,
             "locality_id":101942407,
+            "macroregion_id":1511777407,
+            "neighbourhood_id":-1,
             "region_id":85682053
         }
     ],
     "wof:id":102535145,
-    "wof:lastmodified":1566655367,
+    "wof:lastmodified":1577826457,
     "wof:name":"Aeroporto Araguaina",
     "wof:parent_id":101942407,
     "wof:placetype":"campus",

--- a/data/102/535/147/102535147.geojson
+++ b/data/102/535/147/102535147.geojson
@@ -55,6 +55,7 @@
         85681931,
         102191577,
         85633009,
+        1511777415,
         101942801,
         102052873
     ],
@@ -75,11 +76,13 @@
             "country_id":85633009,
             "county_id":102052873,
             "locality_id":101942801,
+            "macroregion_id":1511777415,
+            "neighbourhood_id":-1,
             "region_id":85681931
         }
     ],
     "wof:id":102535147,
-    "wof:lastmodified":1566655407,
+    "wof:lastmodified":1577841229,
     "wof:name":"Aeroporto Carolina",
     "wof:parent_id":101942801,
     "wof:placetype":"campus",

--- a/data/102/535/149/102535149.geojson
+++ b/data/102/535/149/102535149.geojson
@@ -63,6 +63,7 @@
         102191577,
         404566123,
         85633009,
+        1511777411,
         101952503,
         102061069
     ],
@@ -85,11 +86,13 @@
             "county_id":102061069,
             "localadmin_id":404566123,
             "locality_id":101952503,
+            "macroregion_id":1511777411,
+            "neighbourhood_id":-1,
             "region_id":85682041
         }
     ],
     "wof:id":102535149,
-    "wof:lastmodified":1566655409,
+    "wof:lastmodified":1577835051,
     "wof:name":"Aeroporto Araraquara",
     "wof:parent_id":101952503,
     "wof:placetype":"campus",

--- a/data/102/535/151/102535151.geojson
+++ b/data/102/535/151/102535151.geojson
@@ -70,13 +70,13 @@
         "state_id":2344853
     },
     "wof:belongsto":[
-        85768013,
+        85681947,
         102191577,
         404558855,
         85633009,
+        1511777413,
         101961475,
-        102055213,
-        85681947
+        102055213
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -97,14 +97,15 @@
             "county_id":102055213,
             "localadmin_id":404558855,
             "locality_id":101961475,
-            "neighbourhood_id":85768013,
+            "macroregion_id":1511777413,
+            "neighbourhood_id":-1,
             "region_id":85681947
         }
     ],
     "wof:id":102535151,
-    "wof:lastmodified":1566655350,
+    "wof:lastmodified":1577836749,
     "wof:name":"Aeroporto Internacional Campo Grande",
-    "wof:parent_id":85768013,
+    "wof:parent_id":101961475,
     "wof:placetype":"campus",
     "wof:repo":"whosonfirst-data-admin-xy",
     "wof:superseded_by":[],

--- a/data/102/535/153/102535153.geojson
+++ b/data/102/535/153/102535153.geojson
@@ -60,6 +60,7 @@
         102191577,
         404566147,
         85633009,
+        1511777411,
         102061131
     ],
     "wof:breaches":[],
@@ -79,11 +80,14 @@
             "country_id":85633009,
             "county_id":102061131,
             "localadmin_id":404566147,
+            "locality_id":-1,
+            "macroregion_id":1511777411,
+            "neighbourhood_id":-1,
             "region_id":85682041
         }
     ],
     "wof:id":102535153,
-    "wof:lastmodified":1566655373,
+    "wof:lastmodified":1577835051,
     "wof:name":"Aeroporto Barretos",
     "wof:parent_id":404566147,
     "wof:placetype":"campus",

--- a/data/102/535/157/102535157.geojson
+++ b/data/102/535/157/102535157.geojson
@@ -61,8 +61,11 @@
         "state_id":2344857
     },
     "wof:belongsto":[
+        85681959,
+        102191577,
         85633009,
-        85681959
+        1511777407,
+        102055861
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -78,14 +81,19 @@
     "wof:hierarchy":[
         {
             "campus_id":102535157,
+            "continent_id":102191577,
             "country_id":85633009,
+            "county_id":102055861,
+            "locality_id":-1,
+            "macroregion_id":1511777407,
+            "neighbourhood_id":-1,
             "region_id":85681959
         }
     ],
     "wof:id":102535157,
-    "wof:lastmodified":1566655344,
+    "wof:lastmodified":1577826457,
     "wof:name":"Aeroporto Carajas",
-    "wof:parent_id":85681959,
+    "wof:parent_id":-1,
     "wof:placetype":"campus",
     "wof:repo":"whosonfirst-data-admin-xy",
     "wof:superseded_by":[],

--- a/data/102/535/159/102535159.geojson
+++ b/data/102/535/159/102535159.geojson
@@ -50,6 +50,7 @@
         102191577,
         404560985,
         85633009,
+        1511777409,
         101954811,
         102057541
     ],
@@ -71,11 +72,13 @@
             "county_id":102057541,
             "localadmin_id":404560985,
             "locality_id":101954811,
+            "macroregion_id":1511777409,
+            "neighbourhood_id":-1,
             "region_id":85681983
         }
     ],
     "wof:id":102535159,
-    "wof:lastmodified":1566655345,
+    "wof:lastmodified":1577829509,
     "wof:name":"Aeroporto Campo Mourao",
     "wof:parent_id":101954811,
     "wof:placetype":"campus",

--- a/data/102/535/163/102535163.geojson
+++ b/data/102/535/163/102535163.geojson
@@ -68,6 +68,7 @@
         102191577,
         404550525,
         85633009,
+        1511777415,
         102050549
     ],
     "wof:breaches":[],
@@ -87,11 +88,14 @@
             "country_id":85633009,
             "county_id":102050549,
             "localadmin_id":404550525,
+            "locality_id":-1,
+            "macroregion_id":1511777415,
+            "neighbourhood_id":-1,
             "region_id":85681895
         }
     ],
     "wof:id":102535163,
-    "wof:lastmodified":1566655378,
+    "wof:lastmodified":1577841229,
     "wof:name":"Aeroporto Barreiras",
     "wof:parent_id":404550525,
     "wof:placetype":"campus",

--- a/data/102/535/171/102535171.geojson
+++ b/data/102/535/171/102535171.geojson
@@ -50,6 +50,7 @@
         102191577,
         404550539,
         85633009,
+        1511777415,
         102050557
     ],
     "wof:breaches":[],
@@ -69,11 +70,14 @@
             "country_id":85633009,
             "county_id":102050557,
             "localadmin_id":404550539,
+            "locality_id":-1,
+            "macroregion_id":1511777415,
+            "neighbourhood_id":-1,
             "region_id":85681895
         }
     ],
     "wof:id":102535171,
-    "wof:lastmodified":1566655410,
+    "wof:lastmodified":1577841230,
     "wof:name":"Aeroporto Belmonte",
     "wof:parent_id":404550539,
     "wof:placetype":"campus",

--- a/data/102/535/183/102535183.geojson
+++ b/data/102/535/183/102535183.geojson
@@ -68,6 +68,7 @@
         102191577,
         404555293,
         85633009,
+        1511777411,
         101948709,
         102053465
     ],
@@ -90,11 +91,13 @@
             "county_id":102053465,
             "localadmin_id":404555293,
             "locality_id":101948709,
+            "macroregion_id":1511777411,
+            "neighbourhood_id":-1,
             "region_id":85681941
         }
     ],
     "wof:id":102535183,
-    "wof:lastmodified":1566655403,
+    "wof:lastmodified":1577835051,
     "wof:name":"Aeroporto Romeu Zuma",
     "wof:parent_id":101948709,
     "wof:placetype":"campus",

--- a/data/102/535/185/102535185.geojson
+++ b/data/102/535/185/102535185.geojson
@@ -87,6 +87,7 @@
         85682011,
         102191577,
         85633009,
+        1511777407,
         101941895,
         102059009
     ],
@@ -108,11 +109,13 @@
             "country_id":85633009,
             "county_id":102059009,
             "locality_id":101941895,
+            "macroregion_id":1511777407,
+            "neighbourhood_id":-1,
             "region_id":85682011
         }
     ],
     "wof:id":102535185,
-    "wof:lastmodified":1566655410,
+    "wof:lastmodified":1577826457,
     "wof:name":"Aeroporto Internacional Boa Vista",
     "wof:parent_id":101941895,
     "wof:placetype":"campus",

--- a/data/102/535/187/102535187.geojson
+++ b/data/102/535/187/102535187.geojson
@@ -59,6 +59,7 @@
         102191577,
         404563341,
         85633009,
+        1511777409,
         101960531,
         102059251
     ],
@@ -81,11 +82,13 @@
             "county_id":102059251,
             "localadmin_id":404563341,
             "locality_id":101960531,
+            "macroregion_id":1511777409,
+            "neighbourhood_id":-1,
             "region_id":85682015
         }
     ],
     "wof:id":102535187,
-    "wof:lastmodified":1566655366,
+    "wof:lastmodified":1577829509,
     "wof:name":"Aeroporto Campo dos Bugres",
     "wof:parent_id":101960531,
     "wof:placetype":"campus",

--- a/data/102/535/189/102535189.geojson
+++ b/data/102/535/189/102535189.geojson
@@ -53,6 +53,7 @@
         102191577,
         404550741,
         85633009,
+        1511777415,
         102050657
     ],
     "wof:breaches":[],
@@ -72,11 +73,14 @@
             "country_id":85633009,
             "county_id":102050657,
             "localadmin_id":404550741,
+            "locality_id":-1,
+            "macroregion_id":1511777415,
+            "neighbourhood_id":-1,
             "region_id":85681895
         }
     ],
     "wof:id":102535189,
-    "wof:lastmodified":1566655368,
+    "wof:lastmodified":1577841230,
     "wof:name":"Aeroporto Caravelas",
     "wof:parent_id":404550741,
     "wof:placetype":"campus",

--- a/data/102/535/195/102535195.geojson
+++ b/data/102/535/195/102535195.geojson
@@ -84,11 +84,12 @@
             "county_id":102061141,
             "localadmin_id":404566163,
             "locality_id":101964343,
+            "neighbourhood_id":-1,
             "region_id":85682041
         }
     ],
     "wof:id":102535195,
-    "wof:lastmodified":1566655345,
+    "wof:lastmodified":1577835051,
     "wof:name":"Aeroporto Bauru",
     "wof:parent_id":101964343,
     "wof:placetype":"campus",

--- a/data/102/535/197/102535197.geojson
+++ b/data/102/535/197/102535197.geojson
@@ -65,6 +65,7 @@
         102191577,
         404561031,
         85633009,
+        1511777409,
         102057559
     ],
     "wof:breaches":[],
@@ -85,11 +86,14 @@
             "country_id":85633009,
             "county_id":102057559,
             "localadmin_id":404561031,
+            "locality_id":-1,
+            "macroregion_id":1511777409,
+            "neighbourhood_id":-1,
             "region_id":85681983
         }
     ],
     "wof:id":102535197,
-    "wof:lastmodified":1566655378,
+    "wof:lastmodified":1577829509,
     "wof:name":"Aeroporto Cascavel",
     "wof:parent_id":404561031,
     "wof:placetype":"campus",

--- a/data/102/535/203/102535203.geojson
+++ b/data/102/535/203/102535203.geojson
@@ -141,6 +141,7 @@
         85681911,
         102191577,
         85633009,
+        1511777413,
         101964877,
         102051815
     ],
@@ -162,11 +163,13 @@
             "country_id":85633009,
             "county_id":102051815,
             "locality_id":101964877,
+            "macroregion_id":1511777413,
+            "neighbourhood_id":-1,
             "region_id":85681911
         }
     ],
     "wof:id":102535203,
-    "wof:lastmodified":1566655362,
+    "wof:lastmodified":1577836749,
     "wof:name":"Aeroporto Internacional Juscelino Kubitschek",
     "wof:parent_id":101964877,
     "wof:placetype":"campus",

--- a/data/102/535/205/102535205.geojson
+++ b/data/102/535/205/102535205.geojson
@@ -65,6 +65,7 @@
         102191577,
         404560879,
         85633009,
+        1511777409,
         102057447
     ],
     "wof:breaches":[],
@@ -85,11 +86,14 @@
             "country_id":85633009,
             "county_id":102057447,
             "localadmin_id":404560879,
+            "locality_id":-1,
+            "macroregion_id":1511777409,
+            "neighbourhood_id":-1,
             "region_id":85681983
         }
     ],
     "wof:id":102535205,
-    "wof:lastmodified":1566655365,
+    "wof:lastmodified":1577829508,
     "wof:name":"Aeroporto Arapoti",
     "wof:parent_id":404560879,
     "wof:placetype":"campus",

--- a/data/102/535/211/102535211.geojson
+++ b/data/102/535/211/102535211.geojson
@@ -53,6 +53,7 @@
         85681885,
         102191577,
         85633009,
+        1511777407,
         101941873,
         102050317
     ],
@@ -73,11 +74,13 @@
             "country_id":85633009,
             "county_id":102050317,
             "locality_id":101941873,
+            "macroregion_id":1511777407,
+            "neighbourhood_id":-1,
             "region_id":85681885
         }
     ],
     "wof:id":102535211,
-    "wof:lastmodified":1566655351,
+    "wof:lastmodified":1577826457,
     "wof:name":"Aeroporto Borba",
     "wof:parent_id":101941873,
     "wof:placetype":"campus",

--- a/data/102/535/213/102535213.geojson
+++ b/data/102/535/213/102535213.geojson
@@ -63,6 +63,7 @@
         102191577,
         404559113,
         85633009,
+        1511777413,
         101961703,
         102055381
     ],
@@ -85,11 +86,13 @@
             "county_id":102055381,
             "localadmin_id":404559113,
             "locality_id":101961703,
+            "macroregion_id":1511777413,
+            "neighbourhood_id":-1,
             "region_id":85681955
         }
     ],
     "wof:id":102535213,
-    "wof:lastmodified":1566655390,
+    "wof:lastmodified":1577836749,
     "wof:name":"Aeroporto Barra do Garcas",
     "wof:parent_id":101961703,
     "wof:placetype":"campus",

--- a/data/102/535/215/102535215.geojson
+++ b/data/102/535/215/102535215.geojson
@@ -50,6 +50,7 @@
         102191577,
         404566185,
         85633009,
+        1511777411,
         101964617,
         102061183
     ],
@@ -71,11 +72,13 @@
             "county_id":102061183,
             "localadmin_id":404566185,
             "locality_id":101964617,
+            "macroregion_id":1511777411,
+            "neighbourhood_id":-1,
             "region_id":85682041
         }
     ],
     "wof:id":102535215,
-    "wof:lastmodified":1566655385,
+    "wof:lastmodified":1577835051,
     "wof:name":"Aeroporto Botucatu",
     "wof:parent_id":101964617,
     "wof:placetype":"campus",

--- a/data/102/535/221/102535221.geojson
+++ b/data/102/535/221/102535221.geojson
@@ -69,6 +69,7 @@
         102191577,
         404563021,
         85633009,
+        1511777409,
         102059103
     ],
     "wof:breaches":[],
@@ -88,11 +89,14 @@
             "country_id":85633009,
             "county_id":102059103,
             "localadmin_id":404563021,
+            "locality_id":-1,
+            "macroregion_id":1511777409,
+            "neighbourhood_id":-1,
             "region_id":85682015
         }
     ],
     "wof:id":102535221,
-    "wof:lastmodified":1566655355,
+    "wof:lastmodified":1577829509,
     "wof:name":"Aeroporto Comandante Gustavo Kraemer",
     "wof:parent_id":404563021,
     "wof:placetype":"campus",

--- a/data/102/535/223/102535223.geojson
+++ b/data/102/535/223/102535223.geojson
@@ -59,6 +59,7 @@
         102191577,
         404565245,
         85633009,
+        1511777409,
         102060295
     ],
     "wof:breaches":[],
@@ -79,11 +80,14 @@
             "country_id":85633009,
             "county_id":102060295,
             "localadmin_id":404565245,
+            "locality_id":-1,
+            "macroregion_id":1511777409,
+            "neighbourhood_id":-1,
             "region_id":85682021
         }
     ],
     "wof:id":102535223,
-    "wof:lastmodified":1566655385,
+    "wof:lastmodified":1577829509,
     "wof:name":"Aeroporto Cacador",
     "wof:parent_id":404565245,
     "wof:placetype":"campus",

--- a/data/102/535/225/102535225.geojson
+++ b/data/102/535/225/102535225.geojson
@@ -50,6 +50,7 @@
         102191577,
         404563753,
         85633009,
+        1511777409,
         102059491
     ],
     "wof:breaches":[],
@@ -69,11 +70,14 @@
             "country_id":85633009,
             "county_id":102059491,
             "localadmin_id":404563753,
+            "locality_id":-1,
+            "macroregion_id":1511777409,
+            "neighbourhood_id":-1,
             "region_id":85682015
         }
     ],
     "wof:id":102535225,
-    "wof:lastmodified":1566655388,
+    "wof:lastmodified":1577829509,
     "wof:name":"Aeroporto J. Batista Bos Filho",
     "wof:parent_id":404563753,
     "wof:placetype":"campus",

--- a/data/102/535/231/102535231.geojson
+++ b/data/102/535/231/102535231.geojson
@@ -47,6 +47,7 @@
         102191577,
         404552561,
         85633009,
+        1511777415,
         101944093,
         102051471
     ],
@@ -68,11 +69,13 @@
             "county_id":102051471,
             "localadmin_id":404552561,
             "locality_id":101944093,
+            "macroregion_id":1511777415,
+            "neighbourhood_id":-1,
             "region_id":85681907
         }
     ],
     "wof:id":102535231,
-    "wof:lastmodified":1566655391,
+    "wof:lastmodified":1577841230,
     "wof:name":"Aeroporto Camocim",
     "wof:parent_id":101944093,
     "wof:placetype":"campus",

--- a/data/102/535/233/102535233.geojson
+++ b/data/102/535/233/102535233.geojson
@@ -47,6 +47,7 @@
         102191577,
         404550593,
         85633009,
+        1511777415,
         102050589
     ],
     "wof:breaches":[],
@@ -66,11 +67,14 @@
             "country_id":85633009,
             "county_id":102050589,
             "localadmin_id":404550593,
+            "locality_id":-1,
+            "macroregion_id":1511777415,
+            "neighbourhood_id":-1,
             "region_id":85681895
         }
     ],
     "wof:id":102535233,
-    "wof:lastmodified":1566655365,
+    "wof:lastmodified":1577841230,
     "wof:name":"Aeroporto Brumado",
     "wof:parent_id":404550593,
     "wof:placetype":"campus",

--- a/data/102/535/235/102535235.geojson
+++ b/data/102/535/235/102535235.geojson
@@ -43,8 +43,11 @@
         "state_id":2344854
     },
     "wof:belongsto":[
+        85681931,
+        102191577,
         85633009,
-        85681931
+        1511777415,
+        102052875
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -59,14 +62,19 @@
     "wof:hierarchy":[
         {
             "campus_id":102535235,
+            "continent_id":102191577,
             "country_id":85633009,
+            "county_id":102052875,
+            "locality_id":-1,
+            "macroregion_id":1511777415,
+            "neighbourhood_id":-1,
             "region_id":85681931
         }
     ],
     "wof:id":102535235,
-    "wof:lastmodified":1566655361,
+    "wof:lastmodified":1577841230,
     "wof:name":"Aeroporto Carutapera",
-    "wof:parent_id":85681931,
+    "wof:parent_id":-1,
     "wof:placetype":"campus",
     "wof:repo":"whosonfirst-data-admin-xy",
     "wof:superseded_by":[],

--- a/data/102/535/237/102535237.geojson
+++ b/data/102/535/237/102535237.geojson
@@ -53,6 +53,7 @@
         102191577,
         404563783,
         85633009,
+        1511777409,
         102059517
     ],
     "wof:breaches":[],
@@ -72,11 +73,14 @@
             "country_id":85633009,
             "county_id":102059517,
             "localadmin_id":404563783,
+            "locality_id":-1,
+            "macroregion_id":1511777409,
+            "neighbourhood_id":-1,
             "region_id":85682015
         }
     ],
     "wof:id":102535237,
-    "wof:lastmodified":1566655397,
+    "wof:lastmodified":1577829509,
     "wof:name":"Aeroporto Itaqui",
     "wof:parent_id":404563783,
     "wof:placetype":"campus",

--- a/data/102/535/239/102535239.geojson
+++ b/data/102/535/239/102535239.geojson
@@ -44,6 +44,7 @@
         102191577,
         404558861,
         85633009,
+        1511777413,
         102055217
     ],
     "wof:breaches":[],
@@ -63,11 +64,14 @@
             "country_id":85633009,
             "county_id":102055217,
             "localadmin_id":404558861,
+            "locality_id":-1,
+            "macroregion_id":1511777413,
+            "neighbourhood_id":-1,
             "region_id":85681947
         }
     ],
     "wof:id":102535239,
-    "wof:lastmodified":1566655395,
+    "wof:lastmodified":1577836749,
     "wof:name":"Aeroporto Cassilandia",
     "wof:parent_id":404558861,
     "wof:placetype":"campus",

--- a/data/102/535/241/102535241.geojson
+++ b/data/102/535/241/102535241.geojson
@@ -41,9 +41,10 @@
         "state_id":2344854
     },
     "wof:belongsto":[
-        85633009,
-        101943361,
         85681931,
+        102191577,
+        85633009,
+        1511777415,
         102052951
     ],
     "wof:breaches":[],
@@ -59,16 +60,19 @@
     "wof:hierarchy":[
         {
             "campus_id":102535241,
+            "continent_id":102191577,
             "country_id":85633009,
             "county_id":102052951,
-            "locality_id":101943361,
+            "locality_id":-1,
+            "macroregion_id":1511777415,
+            "neighbourhood_id":-1,
             "region_id":85681931
         }
     ],
     "wof:id":102535241,
-    "wof:lastmodified":1566655383,
+    "wof:lastmodified":1577841230,
     "wof:name":"Aeroporto Guimaraes",
-    "wof:parent_id":101943361,
+    "wof:parent_id":-1,
     "wof:placetype":"campus",
     "wof:repo":"whosonfirst-data-admin-xy",
     "wof:superseded_by":[],

--- a/data/102/535/255/102535255.geojson
+++ b/data/102/535/255/102535255.geojson
@@ -32,6 +32,7 @@
         102191577,
         404550245,
         85633009,
+        1511777407,
         101941573,
         102050315
     ],
@@ -52,11 +53,13 @@
             "county_id":102050315,
             "localadmin_id":404550245,
             "locality_id":101941573,
+            "macroregion_id":1511777407,
+            "neighbourhood_id":-1,
             "region_id":85681885
         }
     ],
     "wof:id":102535255,
-    "wof:lastmodified":1566655398,
+    "wof:lastmodified":1577826458,
     "wof:name":"Aeroporto Boca do Acre",
     "wof:parent_id":101941573,
     "wof:placetype":"campus",

--- a/data/102/535/257/102535257.geojson
+++ b/data/102/535/257/102535257.geojson
@@ -31,6 +31,7 @@
         102191577,
         404563693,
         85633009,
+        1511777409,
         101960699,
         102059455
     ],
@@ -51,11 +52,13 @@
             "county_id":102059455,
             "localadmin_id":404563693,
             "locality_id":101960699,
+            "macroregion_id":1511777409,
+            "neighbourhood_id":-1,
             "region_id":85682015
         }
     ],
     "wof:id":102535257,
-    "wof:lastmodified":1566655359,
+    "wof:lastmodified":1577829509,
     "wof:name":"Aeroporto Gravatai",
     "wof:parent_id":101960699,
     "wof:placetype":"campus",

--- a/data/102/535/259/102535259.geojson
+++ b/data/102/535/259/102535259.geojson
@@ -32,6 +32,7 @@
         102191577,
         404563717,
         85633009,
+        1511777409,
         102059471
     ],
     "wof:breaches":[],
@@ -50,11 +51,14 @@
             "country_id":85633009,
             "county_id":102059471,
             "localadmin_id":404563717,
+            "locality_id":-1,
+            "macroregion_id":1511777409,
+            "neighbourhood_id":-1,
             "region_id":85682015
         }
     ],
     "wof:id":102535259,
-    "wof:lastmodified":1566655360,
+    "wof:lastmodified":1577829510,
     "wof:name":"Aeroporto Horizontina",
     "wof:parent_id":404563717,
     "wof:placetype":"campus",

--- a/data/102/535/261/102535261.geojson
+++ b/data/102/535/261/102535261.geojson
@@ -52,6 +52,7 @@
         85681977,
         102191577,
         85633009,
+        1511777415,
         101943503,
         102057105
     ],
@@ -72,11 +73,13 @@
             "country_id":85633009,
             "county_id":102057105,
             "locality_id":101943503,
+            "macroregion_id":1511777415,
+            "neighbourhood_id":-1,
             "region_id":85681977
         }
     ],
     "wof:id":102535261,
-    "wof:lastmodified":1566655360,
+    "wof:lastmodified":1577841230,
     "wof:name":"Aeroporto Guadalupe",
     "wof:parent_id":101943503,
     "wof:placetype":"campus",

--- a/data/102/535/271/102535271.geojson
+++ b/data/102/535/271/102535271.geojson
@@ -73,6 +73,7 @@
         102191577,
         404566253,
         85633009,
+        1511777411,
         101956069,
         102061235
     ],
@@ -94,11 +95,13 @@
             "county_id":102061235,
             "localadmin_id":404566253,
             "locality_id":101956069,
+            "macroregion_id":1511777411,
+            "neighbourhood_id":-1,
             "region_id":85682041
         }
     ],
     "wof:id":102535271,
-    "wof:lastmodified":1566655388,
+    "wof:lastmodified":1577835051,
     "wof:name":"Aeroporto Internacional Campinas",
     "wof:parent_id":101956069,
     "wof:placetype":"campus",

--- a/data/102/535/273/102535273.geojson
+++ b/data/102/535/273/102535273.geojson
@@ -56,6 +56,7 @@
         102191577,
         404562751,
         85633009,
+        1511777407,
         102058895
     ],
     "wof:breaches":[],
@@ -76,11 +77,14 @@
             "country_id":85633009,
             "county_id":102058895,
             "localadmin_id":404562751,
+            "locality_id":-1,
+            "macroregion_id":1511777407,
+            "neighbourhood_id":-1,
             "region_id":85682003
         }
     ],
     "wof:id":102535273,
-    "wof:lastmodified":1566655353,
+    "wof:lastmodified":1577826458,
     "wof:name":"Aeroporto Cacoal",
     "wof:parent_id":404562751,
     "wof:placetype":"campus",

--- a/data/102/535/275/102535275.geojson
+++ b/data/102/535/275/102535275.geojson
@@ -65,6 +65,7 @@
         85682041,
         102191577,
         85633009,
+        1511777411,
         101956207,
         102061185
     ],
@@ -86,11 +87,13 @@
             "country_id":85633009,
             "county_id":102061185,
             "locality_id":101956207,
+            "macroregion_id":1511777411,
+            "neighbourhood_id":-1,
             "region_id":85682041
         }
     ],
     "wof:id":102535275,
-    "wof:lastmodified":1566655359,
+    "wof:lastmodified":1577835052,
     "wof:name":"Aeroporto Braganca Paulista",
     "wof:parent_id":101956207,
     "wof:placetype":"campus",

--- a/data/102/535/277/102535277.geojson
+++ b/data/102/535/277/102535277.geojson
@@ -47,8 +47,9 @@
         102191577,
         404555011,
         85633009,
+        1511777415,
         101943337,
-        102053207
+        102052905
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -65,14 +66,16 @@
             "campus_id":102535277,
             "continent_id":102191577,
             "country_id":85633009,
-            "county_id":102053207,
+            "county_id":102052905,
             "localadmin_id":404555011,
             "locality_id":101943337,
+            "macroregion_id":1511777415,
+            "neighbourhood_id":-1,
             "region_id":85681931
         }
     ],
     "wof:id":102535277,
-    "wof:lastmodified":1566655382,
+    "wof:lastmodified":1577841230,
     "wof:name":"Aeroporto Cururupu",
     "wof:parent_id":101943337,
     "wof:placetype":"campus",

--- a/data/102/535/279/102535279.geojson
+++ b/data/102/535/279/102535279.geojson
@@ -50,6 +50,7 @@
         102191577,
         404559637,
         85633009,
+        1511777407,
         102055795
     ],
     "wof:breaches":[],
@@ -69,11 +70,14 @@
             "country_id":85633009,
             "county_id":102055795,
             "localadmin_id":404559637,
+            "locality_id":-1,
+            "macroregion_id":1511777407,
+            "neighbourhood_id":-1,
             "region_id":85681959
         }
     ],
     "wof:id":102535279,
-    "wof:lastmodified":1566655384,
+    "wof:lastmodified":1577826458,
     "wof:name":"Aeroporto de Jacar\u00e9pagua",
     "wof:parent_id":404559637,
     "wof:placetype":"campus",

--- a/data/102/535/289/102535289.geojson
+++ b/data/102/535/289/102535289.geojson
@@ -47,6 +47,7 @@
         102191577,
         404551163,
         85633009,
+        1511777415,
         101950063,
         102050859
     ],
@@ -68,11 +69,13 @@
             "county_id":102050859,
             "localadmin_id":404551163,
             "locality_id":101950063,
+            "macroregion_id":1511777415,
+            "neighbourhood_id":-1,
             "region_id":85681895
         }
     ],
     "wof:id":102535289,
-    "wof:lastmodified":1566655354,
+    "wof:lastmodified":1577841231,
     "wof:name":"Aeroporto Itabuna",
     "wof:parent_id":101950063,
     "wof:placetype":"campus",

--- a/data/102/535/295/102535295.geojson
+++ b/data/102/535/295/102535295.geojson
@@ -66,6 +66,7 @@
         102191577,
         404551091,
         85633009,
+        1511777415,
         101950153,
         102050831
     ],
@@ -87,11 +88,13 @@
             "county_id":102050831,
             "localadmin_id":404551091,
             "locality_id":101950153,
+            "macroregion_id":1511777415,
+            "neighbourhood_id":-1,
             "region_id":85681895
         }
     ],
     "wof:id":102535295,
-    "wof:lastmodified":1566655360,
+    "wof:lastmodified":1577841231,
     "wof:name":"Aeroporto Jorge Amado",
     "wof:parent_id":101950153,
     "wof:placetype":"campus",

--- a/data/102/535/321/102535321.geojson
+++ b/data/102/535/321/102535321.geojson
@@ -44,6 +44,7 @@
         102191577,
         404553005,
         85633009,
+        1511777415,
         101944441,
         102051573
     ],
@@ -65,11 +66,13 @@
             "county_id":102051573,
             "localadmin_id":404553005,
             "locality_id":101944441,
+            "macroregion_id":1511777415,
+            "neighbourhood_id":-1,
             "region_id":85681907
         }
     ],
     "wof:id":102535321,
-    "wof:lastmodified":1566655406,
+    "wof:lastmodified":1577841231,
     "wof:name":"Aeroporto Iguatu",
     "wof:parent_id":101944441,
     "wof:placetype":"campus",

--- a/data/102/535/323/102535323.geojson
+++ b/data/102/535/323/102535323.geojson
@@ -62,6 +62,7 @@
         102191577,
         404556227,
         85633009,
+        1511777411,
         101965973,
         102053805
     ],
@@ -83,11 +84,13 @@
             "county_id":102053805,
             "localadmin_id":404556227,
             "locality_id":101965973,
+            "macroregion_id":1511777411,
+            "neighbourhood_id":-1,
             "region_id":85681941
         }
     ],
     "wof:id":102535323,
-    "wof:lastmodified":1566655369,
+    "wof:lastmodified":1577835053,
     "wof:name":"Aeroporto Divinopolis",
     "wof:parent_id":101965973,
     "wof:placetype":"campus",

--- a/data/102/535/325/102535325.geojson
+++ b/data/102/535/325/102535325.geojson
@@ -32,6 +32,7 @@
         102191577,
         404556307,
         85633009,
+        1511777411,
         101951629,
         102053861
     ],
@@ -53,11 +54,13 @@
             "county_id":102053861,
             "localadmin_id":404556307,
             "locality_id":101951629,
+            "macroregion_id":1511777411,
+            "neighbourhood_id":-1,
             "region_id":85681941
         }
     ],
     "wof:id":102535325,
-    "wof:lastmodified":1566655373,
+    "wof:lastmodified":1577835053,
     "wof:name":"Aeroporto Espinosa",
     "wof:parent_id":101951629,
     "wof:placetype":"campus",

--- a/data/102/535/327/102535327.geojson
+++ b/data/102/535/327/102535327.geojson
@@ -91,6 +91,7 @@
         102191577,
         404551875,
         85633009,
+        1511777415,
         101950447,
         102051217
     ],
@@ -113,11 +114,13 @@
             "county_id":102051217,
             "localadmin_id":404551875,
             "locality_id":101950447,
+            "macroregion_id":1511777415,
+            "neighbourhood_id":-1,
             "region_id":85681895
         }
     ],
     "wof:id":102535327,
-    "wof:lastmodified":1566655400,
+    "wof:lastmodified":1577841231,
     "wof:name":"Aeroporto Internacional Dep. Lu\u00eds Eduardo Magalh\u00e3es",
     "wof:parent_id":101950447,
     "wof:placetype":"campus",

--- a/data/102/535/337/102535337.geojson
+++ b/data/102/535/337/102535337.geojson
@@ -67,6 +67,7 @@
         85681885,
         102191577,
         85633009,
+        1511777407,
         101941527,
         102050335
     ],
@@ -87,11 +88,13 @@
             "country_id":85633009,
             "county_id":102050335,
             "locality_id":101941527,
+            "macroregion_id":1511777407,
+            "neighbourhood_id":-1,
             "region_id":85681885
         }
     ],
     "wof:id":102535337,
-    "wof:lastmodified":1566655347,
+    "wof:lastmodified":1577826460,
     "wof:name":"Aeroporto Eirunepe",
     "wof:parent_id":101941527,
     "wof:placetype":"campus",

--- a/data/102/535/349/102535349.geojson
+++ b/data/102/535/349/102535349.geojson
@@ -50,6 +50,7 @@
         102191577,
         404558573,
         85633009,
+        1511777411,
         102055061
     ],
     "wof:breaches":[],
@@ -69,11 +70,14 @@
             "country_id":85633009,
             "county_id":102055061,
             "localadmin_id":404558573,
+            "locality_id":-1,
+            "macroregion_id":1511777411,
+            "neighbourhood_id":-1,
             "region_id":85681941
         }
     ],
     "wof:id":102535349,
-    "wof:lastmodified":1566655371,
+    "wof:lastmodified":1577835054,
     "wof:name":"Aeroporto Juscelino Kubitscheck",
     "wof:parent_id":404558573,
     "wof:placetype":"campus",

--- a/data/102/535/359/102535359.geojson
+++ b/data/102/535/359/102535359.geojson
@@ -62,6 +62,7 @@
         102191577,
         404556485,
         85633009,
+        1511777411,
         101966419,
         102053957
     ],
@@ -83,11 +84,13 @@
             "county_id":102053957,
             "localadmin_id":404556485,
             "locality_id":101966419,
+            "macroregion_id":1511777411,
+            "neighbourhood_id":-1,
             "region_id":85681941
         }
     ],
     "wof:id":102535359,
-    "wof:lastmodified":1566655374,
+    "wof:lastmodified":1577835054,
     "wof:name":"Aeroporto Governador Valadares",
     "wof:parent_id":101966419,
     "wof:placetype":"campus",

--- a/data/102/535/363/102535363.geojson
+++ b/data/102/535/363/102535363.geojson
@@ -55,6 +55,7 @@
         85681999,
         102191577,
         85633009,
+        1511777415,
         101946199,
         102058707
     ],
@@ -76,11 +77,13 @@
             "country_id":85633009,
             "county_id":102058707,
             "locality_id":101946199,
+            "macroregion_id":1511777415,
+            "neighbourhood_id":-1,
             "region_id":85681999
         }
     ],
     "wof:id":102535363,
-    "wof:lastmodified":1566655350,
+    "wof:lastmodified":1577841232,
     "wof:name":"Aeroporto Dix-Sept Rosado",
     "wof:parent_id":101946199,
     "wof:placetype":"campus",

--- a/data/102/535/381/102535381.geojson
+++ b/data/102/535/381/102535381.geojson
@@ -53,6 +53,7 @@
         102191577,
         404561191,
         85633009,
+        1511777409,
         101963125,
         102057693
     ],
@@ -74,11 +75,13 @@
             "county_id":102057693,
             "localadmin_id":404561191,
             "locality_id":101963125,
+            "macroregion_id":1511777409,
+            "neighbourhood_id":-1,
             "region_id":85681983
         }
     ],
     "wof:id":102535381,
-    "wof:lastmodified":1566655408,
+    "wof:lastmodified":1577829511,
     "wof:name":"Aeroporto Guaira",
     "wof:parent_id":101963125,
     "wof:placetype":"campus",

--- a/data/102/535/391/102535391.geojson
+++ b/data/102/535/391/102535391.geojson
@@ -100,6 +100,7 @@
         102191577,
         404560597,
         85633009,
+        1511777415,
         101948669,
         102056781
     ],
@@ -122,11 +123,13 @@
             "county_id":102056781,
             "localadmin_id":404560597,
             "locality_id":101948669,
+            "macroregion_id":1511777415,
+            "neighbourhood_id":-1,
             "region_id":85681973
         }
     ],
     "wof:id":102535391,
-    "wof:lastmodified":1566655344,
+    "wof:lastmodified":1577841232,
     "wof:name":"Aeroporto Internacional Gilberto Freyre",
     "wof:parent_id":101948669,
     "wof:placetype":"campus",

--- a/data/102/535/393/102535393.geojson
+++ b/data/102/535/393/102535393.geojson
@@ -53,6 +53,7 @@
         102191577,
         404562773,
         85633009,
+        1511777407,
         102058907
     ],
     "wof:breaches":[],
@@ -72,11 +73,14 @@
             "country_id":85633009,
             "county_id":102058907,
             "localadmin_id":404562773,
+            "locality_id":-1,
+            "macroregion_id":1511777407,
+            "neighbourhood_id":-1,
             "region_id":85682003
         }
     ],
     "wof:id":102535393,
-    "wof:lastmodified":1566655379,
+    "wof:lastmodified":1577826460,
     "wof:name":"Aeroporto Guajara Mirim",
     "wof:parent_id":404562773,
     "wof:placetype":"campus",

--- a/data/102/535/395/102535395.geojson
+++ b/data/102/535/395/102535395.geojson
@@ -59,6 +59,7 @@
         102191577,
         404561089,
         85633009,
+        1511777409,
         102057595
     ],
     "wof:breaches":[],
@@ -78,11 +79,14 @@
             "country_id":85633009,
             "county_id":102057595,
             "localadmin_id":404561089,
+            "locality_id":-1,
+            "macroregion_id":1511777409,
+            "neighbourhood_id":-1,
             "region_id":85681983
         }
     ],
     "wof:id":102535395,
-    "wof:lastmodified":1566655374,
+    "wof:lastmodified":1577829511,
     "wof:name":"Aeroporto Cornelio Procopio",
     "wof:parent_id":404561089,
     "wof:placetype":"campus",

--- a/data/102/535/403/102535403.geojson
+++ b/data/102/535/403/102535403.geojson
@@ -71,6 +71,7 @@
         102191577,
         404558871,
         85633009,
+        1511777413,
         101961067,
         102055227
     ],
@@ -93,11 +94,13 @@
             "county_id":102055227,
             "localadmin_id":404558871,
             "locality_id":101961067,
+            "macroregion_id":1511777413,
+            "neighbourhood_id":-1,
             "region_id":85681947
         }
     ],
     "wof:id":102535403,
-    "wof:lastmodified":1566655399,
+    "wof:lastmodified":1577836750,
     "wof:name":"Aeroporto Internacional Corumba",
     "wof:parent_id":101961067,
     "wof:placetype":"campus",

--- a/data/102/535/405/102535405.geojson
+++ b/data/102/535/405/102535405.geojson
@@ -75,13 +75,13 @@
         "state_id":2344867
     },
     "wof:belongsto":[
-        85767513,
+        85682021,
         102191577,
         404565415,
         85633009,
+        1511777409,
         101958191,
-        102060383,
-        85682021
+        102060383
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -98,14 +98,15 @@
             "county_id":102060383,
             "localadmin_id":404565415,
             "locality_id":101958191,
-            "neighbourhood_id":85767513,
+            "macroregion_id":1511777409,
+            "neighbourhood_id":-1,
             "region_id":85682021
         }
     ],
     "wof:id":102535405,
-    "wof:lastmodified":1566655393,
+    "wof:lastmodified":1577829511,
     "wof:name":"Aeroporto Internacional Herc\u00edlio Luz",
-    "wof:parent_id":85767513,
+    "wof:parent_id":101958191,
     "wof:placetype":"campus",
     "wof:repo":"whosonfirst-data-admin-xy",
     "wof:superseded_by":[],

--- a/data/102/535/413/102535413.geojson
+++ b/data/102/535/413/102535413.geojson
@@ -151,6 +151,7 @@
         102191577,
         404566473,
         85633009,
+        1511777411,
         101956159,
         102061469
     ],
@@ -173,11 +174,13 @@
             "county_id":102061469,
             "localadmin_id":404566473,
             "locality_id":101956159,
+            "macroregion_id":1511777411,
+            "neighbourhood_id":-1,
             "region_id":85682041
         }
     ],
     "wof:id":102535413,
-    "wof:lastmodified":1566655354,
+    "wof:lastmodified":1577835055,
     "wof:name":"Sao Paulo-Guarulhos International Airport",
     "wof:parent_id":101956159,
     "wof:placetype":"campus",

--- a/data/102/535/415/102535415.geojson
+++ b/data/102/535/415/102535415.geojson
@@ -59,6 +59,7 @@
         102191577,
         404562787,
         85633009,
+        1511777407,
         102058913
     ],
     "wof:breaches":[],
@@ -79,11 +80,14 @@
             "country_id":85633009,
             "county_id":102058913,
             "localadmin_id":404562787,
+            "locality_id":-1,
+            "macroregion_id":1511777407,
+            "neighbourhood_id":-1,
             "region_id":85682003
         }
     ],
     "wof:id":102535415,
-    "wof:lastmodified":1566655358,
+    "wof:lastmodified":1577826462,
     "wof:name":"Aeroporto Ji Parana",
     "wof:parent_id":404562787,
     "wof:placetype":"campus",

--- a/data/102/535/417/102535417.geojson
+++ b/data/102/535/417/102535417.geojson
@@ -53,6 +53,7 @@
         102191577,
         404556843,
         85633009,
+        1511777411,
         101950955,
         102054147
     ],
@@ -74,11 +75,13 @@
             "county_id":102054147,
             "localadmin_id":404556843,
             "locality_id":101950955,
+            "macroregion_id":1511777411,
+            "neighbourhood_id":-1,
             "region_id":85681941
         }
     ],
     "wof:id":102535417,
-    "wof:lastmodified":1566655383,
+    "wof:lastmodified":1577835056,
     "wof:name":"Aeroporto Januaria",
     "wof:parent_id":101950955,
     "wof:placetype":"campus",

--- a/data/102/535/419/102535419.geojson
+++ b/data/102/535/419/102535419.geojson
@@ -53,6 +53,7 @@
         102191577,
         404562757,
         85633009,
+        1511777407,
         102058903
     ],
     "wof:breaches":[],
@@ -72,11 +73,14 @@
             "country_id":85633009,
             "county_id":102058903,
             "localadmin_id":404562757,
+            "locality_id":-1,
+            "macroregion_id":1511777407,
+            "neighbourhood_id":-1,
             "region_id":85682003
         }
     ],
     "wof:id":102535419,
-    "wof:lastmodified":1566655381,
+    "wof:lastmodified":1577826462,
     "wof:name":"Aeroporto Costa Marques",
     "wof:parent_id":404562757,
     "wof:placetype":"campus",

--- a/data/102/535/439/102535439.geojson
+++ b/data/102/535/439/102535439.geojson
@@ -58,6 +58,7 @@
         85682053,
         102191577,
         85633009,
+        1511777407,
         101942409,
         102062571
     ],
@@ -78,11 +79,13 @@
             "country_id":85633009,
             "county_id":102062571,
             "locality_id":101942409,
+            "macroregion_id":1511777407,
+            "neighbourhood_id":-1,
             "region_id":85682053
         }
     ],
     "wof:id":102535439,
-    "wof:lastmodified":1566655360,
+    "wof:lastmodified":1577826461,
     "wof:name":"Aeroporto Gurupi",
     "wof:parent_id":101942409,
     "wof:placetype":"campus",

--- a/data/102/535/449/102535449.geojson
+++ b/data/102/535/449/102535449.geojson
@@ -53,6 +53,7 @@
         102191577,
         404551313,
         85633009,
+        1511777415,
         101949797,
         102050941
     ],
@@ -74,11 +75,13 @@
             "county_id":102050941,
             "localadmin_id":404551313,
             "locality_id":101949797,
+            "macroregion_id":1511777415,
+            "neighbourhood_id":-1,
             "region_id":85681895
         }
     ],
     "wof:id":102535449,
-    "wof:lastmodified":1566655353,
+    "wof:lastmodified":1577841234,
     "wof:name":"Aeroporto Jequie",
     "wof:parent_id":101949797,
     "wof:placetype":"campus",

--- a/data/102/535/451/102535451.geojson
+++ b/data/102/535/451/102535451.geojson
@@ -53,6 +53,7 @@
         102191577,
         404550267,
         85633009,
+        1511777407,
         102050351
     ],
     "wof:breaches":[],
@@ -72,11 +73,14 @@
             "country_id":85633009,
             "county_id":102050351,
             "localadmin_id":404550267,
+            "locality_id":-1,
+            "macroregion_id":1511777407,
+            "neighbourhood_id":-1,
             "region_id":85681885
         }
     ],
     "wof:id":102535451,
-    "wof:lastmodified":1566655393,
+    "wof:lastmodified":1577826462,
     "wof:name":"Aeroporto Itacoatiara",
     "wof:parent_id":404550267,
     "wof:placetype":"campus",

--- a/data/102/535/457/102535457.geojson
+++ b/data/102/535/457/102535457.geojson
@@ -62,6 +62,7 @@
         102191577,
         404558925,
         85633009,
+        1511777413,
         102055241
     ],
     "wof:breaches":[],
@@ -82,11 +83,14 @@
             "country_id":85633009,
             "county_id":102055241,
             "localadmin_id":404558925,
+            "locality_id":-1,
+            "macroregion_id":1511777413,
+            "neighbourhood_id":-1,
             "region_id":85681947
         }
     ],
     "wof:id":102535457,
-    "wof:lastmodified":1566655396,
+    "wof:lastmodified":1577836751,
     "wof:name":"Aeroporto Dourados",
     "wof:parent_id":404558925,
     "wof:placetype":"campus",

--- a/data/102/535/463/102535463.geojson
+++ b/data/102/535/463/102535463.geojson
@@ -59,6 +59,7 @@
         102191577,
         404561209,
         85633009,
+        1511777409,
         101957167,
         102057709
     ],
@@ -80,11 +81,13 @@
             "county_id":102057709,
             "localadmin_id":404561209,
             "locality_id":101957167,
+            "macroregion_id":1511777409,
+            "neighbourhood_id":-1,
             "region_id":85681983
         }
     ],
     "wof:id":102535463,
-    "wof:lastmodified":1566655361,
+    "wof:lastmodified":1577829513,
     "wof:name":"Aeroporto Tancredo Thomaz Faria",
     "wof:parent_id":101957167,
     "wof:placetype":"campus",

--- a/data/102/535/471/102535471.geojson
+++ b/data/102/535/471/102535471.geojson
@@ -65,6 +65,7 @@
         102191577,
         404555027,
         85633009,
+        1511777415,
         101943107,
         102052963
     ],
@@ -86,11 +87,13 @@
             "county_id":102052963,
             "localadmin_id":404555027,
             "locality_id":101943107,
+            "macroregion_id":1511777415,
+            "neighbourhood_id":-1,
             "region_id":85681931
         }
     ],
     "wof:id":102535471,
-    "wof:lastmodified":1566655352,
+    "wof:lastmodified":1577841234,
     "wof:name":"Aeroporto Prefeito Renato Moreira",
     "wof:parent_id":101943107,
     "wof:placetype":"campus",

--- a/data/102/535/477/102535477.geojson
+++ b/data/102/535/477/102535477.geojson
@@ -64,6 +64,7 @@
         85681959,
         102191577,
         85633009,
+        1511777407,
         101941999,
         102055791
     ],
@@ -84,11 +85,13 @@
             "country_id":85633009,
             "county_id":102055791,
             "locality_id":101941999,
+            "macroregion_id":1511777407,
+            "neighbourhood_id":-1,
             "region_id":85681959
         }
     ],
     "wof:id":102535477,
-    "wof:lastmodified":1566655355,
+    "wof:lastmodified":1577826463,
     "wof:name":"Aeroporto Itaituba",
     "wof:parent_id":101941999,
     "wof:placetype":"campus",

--- a/data/102/535/481/102535481.geojson
+++ b/data/102/535/481/102535481.geojson
@@ -65,6 +65,7 @@
         102191577,
         404551003,
         85633009,
+        1511777415,
         101949207,
         102050783
     ],
@@ -86,11 +87,13 @@
             "county_id":102050783,
             "localadmin_id":404551003,
             "locality_id":101949207,
+            "macroregion_id":1511777415,
+            "neighbourhood_id":-1,
             "region_id":85681895
         }
     ],
     "wof:id":102535481,
-    "wof:lastmodified":1566655385,
+    "wof:lastmodified":1577841234,
     "wof:name":"Aeroporto Guanambi",
     "wof:parent_id":101949207,
     "wof:placetype":"campus",

--- a/data/102/535/483/102535483.geojson
+++ b/data/102/535/483/102535483.geojson
@@ -67,8 +67,11 @@
         "state_id":2344844
     },
     "wof:belongsto":[
+        85681873,
+        102191577,
         85633009,
-        85681873
+        1511777407,
+        102050021
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -84,14 +87,19 @@
     "wof:hierarchy":[
         {
             "campus_id":102535483,
+            "continent_id":102191577,
             "country_id":85633009,
+            "county_id":102050021,
+            "locality_id":-1,
+            "macroregion_id":1511777407,
+            "neighbourhood_id":-1,
             "region_id":85681873
         }
     ],
     "wof:id":102535483,
-    "wof:lastmodified":1566655355,
+    "wof:lastmodified":1577826462,
     "wof:name":"Aeroporto Internacional Cruzeiro do Sul",
-    "wof:parent_id":85681873,
+    "wof:parent_id":-1,
     "wof:placetype":"campus",
     "wof:repo":"whosonfirst-data-admin-xy",
     "wof:superseded_by":[],

--- a/data/102/535/485/102535485.geojson
+++ b/data/102/535/485/102535485.geojson
@@ -74,6 +74,7 @@
         102191577,
         404565423,
         85633009,
+        1511777409,
         102060389
     ],
     "wof:breaches":[],
@@ -94,11 +95,14 @@
             "country_id":85633009,
             "county_id":102060389,
             "localadmin_id":404565423,
+            "locality_id":-1,
+            "macroregion_id":1511777409,
+            "neighbourhood_id":-1,
             "region_id":85682021
         }
     ],
     "wof:id":102535485,
-    "wof:lastmodified":1566655352,
+    "wof:lastmodified":1577829513,
     "wof:name":"Aeroporto Criciuma",
     "wof:parent_id":404565423,
     "wof:placetype":"campus",

--- a/data/102/535/643/102535643.geojson
+++ b/data/102/535/643/102535643.geojson
@@ -161,9 +161,11 @@
         "suburb_id":744690
     },
     "wof:belongsto":[
-        102191581,
-        85633735,
         85799047,
+        102191581,
+        1511679077,
+        85633735,
+        101752087,
         85687367
     ],
     "wof:breaches":[],
@@ -180,12 +182,14 @@
             "campus_id":102535643,
             "continent_id":102191581,
             "country_id":85633735,
+            "localadmin_id":1511679077,
+            "locality_id":101752087,
             "neighbourhood_id":85799047,
             "region_id":85687367
         }
     ],
     "wof:id":102535643,
-    "wof:lastmodified":1566655352,
+    "wof:lastmodified":1579720770,
     "wof:name":"Lisbon Portela Airport",
     "wof:parent_id":85799047,
     "wof:placetype":"campus",

--- a/data/102/535/645/102535645.geojson
+++ b/data/102/535/645/102535645.geojson
@@ -50,8 +50,10 @@
         "state_id":2346579
     },
     "wof:belongsto":[
-        85633735,
-        85687423
+        85687423,
+        102191581,
+        1511684711,
+        85633735
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -66,14 +68,18 @@
     "wof:hierarchy":[
         {
             "campus_id":102535645,
+            "continent_id":102191581,
             "country_id":85633735,
+            "localadmin_id":1511684711,
+            "locality_id":-1,
+            "neighbourhood_id":-1,
             "region_id":85687423
         }
     ],
     "wof:id":102535645,
-    "wof:lastmodified":1566655355,
+    "wof:lastmodified":1579720768,
     "wof:name":"Chaves Airport",
-    "wof:parent_id":85687423,
+    "wof:parent_id":1511684711,
     "wof:placetype":"campus",
     "wof:repo":"whosonfirst-data-admin-xy",
     "wof:superseded_by":[],

--- a/data/102/535/647/102535647.geojson
+++ b/data/102/535/647/102535647.geojson
@@ -76,8 +76,10 @@
         "state_id":15021776
     },
     "wof:belongsto":[
-        85633735,
-        85687469
+        1511614891,
+        102191581,
+        1511685481,
+        85633735
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -92,14 +94,18 @@
     "wof:hierarchy":[
         {
             "campus_id":102535647,
+            "continent_id":102191581,
             "country_id":85633735,
-            "region_id":85687469
+            "localadmin_id":1511685481,
+            "locality_id":-1,
+            "neighbourhood_id":-1,
+            "region_id":1511614891
         }
     ],
     "wof:id":102535647,
-    "wof:lastmodified":1566655385,
+    "wof:lastmodified":1579720768,
     "wof:name":"Corvo Island Airport",
-    "wof:parent_id":85687469,
+    "wof:parent_id":1511685481,
     "wof:placetype":"campus",
     "wof:repo":"whosonfirst-data-admin-xy",
     "wof:superseded_by":[],

--- a/data/102/535/649/102535649.geojson
+++ b/data/102/535/649/102535649.geojson
@@ -59,9 +59,10 @@
         "state_id":2346569
     },
     "wof:belongsto":[
-        85633735,
-        101832767,
-        85687349
+        85687349,
+        102191581,
+        1511678905,
+        85633735
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -76,15 +77,18 @@
     "wof:hierarchy":[
         {
             "campus_id":102535649,
+            "continent_id":102191581,
             "country_id":85633735,
-            "locality_id":101832767,
+            "localadmin_id":1511678905,
+            "locality_id":-1,
+            "neighbourhood_id":-1,
             "region_id":85687349
         }
     ],
     "wof:id":102535649,
-    "wof:lastmodified":1566655385,
+    "wof:lastmodified":1579720769,
     "wof:name":"Portimao Airport",
-    "wof:parent_id":101832767,
+    "wof:parent_id":1511678905,
     "wof:placetype":"campus",
     "wof:repo":"whosonfirst-data-admin-xy",
     "wof:superseded_by":[],

--- a/data/102/535/651/102535651.geojson
+++ b/data/102/535/651/102535651.geojson
@@ -89,8 +89,10 @@
         "state_id":2346570
     },
     "wof:belongsto":[
-        85633735,
-        85687341
+        1511614893,
+        102191581,
+        1511685541,
+        85633735
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -106,14 +108,18 @@
     "wof:hierarchy":[
         {
             "campus_id":102535651,
+            "continent_id":102191581,
             "country_id":85633735,
-            "region_id":85687341
+            "localadmin_id":1511685541,
+            "locality_id":-1,
+            "neighbourhood_id":-1,
+            "region_id":1511614893
         }
     ],
     "wof:id":102535651,
-    "wof:lastmodified":1566655361,
+    "wof:lastmodified":1579720769,
     "wof:name":"Aeroporto de Porto Santo",
-    "wof:parent_id":85687341,
+    "wof:parent_id":1511685541,
     "wof:placetype":"campus",
     "wof:repo":"whosonfirst-data-admin-xy",
     "wof:superseded_by":[],

--- a/data/102/535/661/102535661.geojson
+++ b/data/102/535/661/102535661.geojson
@@ -47,8 +47,10 @@
         "state_id":2346565
     },
     "wof:belongsto":[
-        85633735,
-        85687415
+        85687415,
+        102191581,
+        1511685065,
+        85633735
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -63,14 +65,18 @@
     "wof:hierarchy":[
         {
             "campus_id":102535661,
+            "continent_id":102191581,
             "country_id":85633735,
+            "localadmin_id":1511685065,
+            "locality_id":-1,
+            "neighbourhood_id":-1,
             "region_id":85687415
         }
     ],
     "wof:id":102535661,
-    "wof:lastmodified":1566655365,
+    "wof:lastmodified":1579720767,
     "wof:name":"Braganca Airport",
-    "wof:parent_id":85687415,
+    "wof:parent_id":1511685065,
     "wof:placetype":"campus",
     "wof:repo":"whosonfirst-data-admin-xy",
     "wof:superseded_by":[],

--- a/data/102/535/665/102535665.geojson
+++ b/data/102/535/665/102535665.geojson
@@ -108,8 +108,10 @@
         "state_id":2346569
     },
     "wof:belongsto":[
-        85633735,
-        85687349
+        85687349,
+        102191581,
+        1511678857,
+        85633735
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -121,14 +123,18 @@
     "wof:hierarchy":[
         {
             "campus_id":102535665,
+            "continent_id":102191581,
             "country_id":85633735,
+            "localadmin_id":1511678857,
+            "locality_id":-1,
+            "neighbourhood_id":-1,
             "region_id":85687349
         }
     ],
     "wof:id":102535665,
-    "wof:lastmodified":1566655396,
+    "wof:lastmodified":1579720769,
     "wof:name":"Aeroporto d\u00e9 F\u00e5r\u00f6",
-    "wof:parent_id":85687349,
+    "wof:parent_id":1511678857,
     "wof:placetype":"campus",
     "wof:repo":"whosonfirst-data-admin-xy",
     "wof:superseded_by":[],

--- a/data/102/535/671/102535671.geojson
+++ b/data/102/535/671/102535671.geojson
@@ -53,8 +53,10 @@
         "state_id":2346567
     },
     "wof:belongsto":[
-        85633735,
-        85687391
+        85687391,
+        102191581,
+        1511681053,
+        85633735
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -69,14 +71,18 @@
     "wof:hierarchy":[
         {
             "campus_id":102535671,
+            "continent_id":102191581,
             "country_id":85633735,
+            "localadmin_id":1511681053,
+            "locality_id":-1,
+            "neighbourhood_id":-1,
             "region_id":85687391
         }
     ],
     "wof:id":102535671,
-    "wof:lastmodified":1566655385,
+    "wof:lastmodified":1579720768,
     "wof:name":"Coimbra Airport",
-    "wof:parent_id":85687391,
+    "wof:parent_id":1511681053,
     "wof:placetype":"campus",
     "wof:repo":"whosonfirst-data-admin-xy",
     "wof:superseded_by":[],

--- a/data/102/535/673/102535673.geojson
+++ b/data/102/535/673/102535673.geojson
@@ -71,10 +71,11 @@
         "state_id":2346564
     },
     "wof:belongsto":[
+        85687419,
         102191581,
+        1511683597,
         85633735,
-        101752097,
-        85687419
+        101752097
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -92,12 +93,14 @@
             "campus_id":102535673,
             "continent_id":102191581,
             "country_id":85633735,
+            "localadmin_id":1511683597,
             "locality_id":101752097,
+            "neighbourhood_id":-1,
             "region_id":85687419
         }
     ],
     "wof:id":102535673,
-    "wof:lastmodified":1566655357,
+    "wof:lastmodified":1579720767,
     "wof:name":"Braga Airport",
     "wof:parent_id":101752097,
     "wof:placetype":"campus",

--- a/data/102/535/675/102535675.geojson
+++ b/data/102/535/675/102535675.geojson
@@ -44,8 +44,10 @@
         "state_id":2346566
     },
     "wof:belongsto":[
-        85633735,
-        85687385
+        85687385,
+        102191581,
+        1125395747,
+        85633735
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -60,14 +62,18 @@
     "wof:hierarchy":[
         {
             "campus_id":102535675,
+            "continent_id":102191581,
             "country_id":85633735,
+            "localadmin_id":1125395747,
+            "locality_id":-1,
+            "neighbourhood_id":-1,
             "region_id":85687385
         }
     ],
     "wof:id":102535675,
-    "wof:lastmodified":1566655351,
+    "wof:lastmodified":1579655019,
     "wof:name":"Covilha Airport",
-    "wof:parent_id":85687385,
+    "wof:parent_id":1125395747,
     "wof:placetype":"campus",
     "wof:repo":"whosonfirst-data-admin-xy",
     "wof:superseded_by":[],

--- a/data/102/535/679/102535679.geojson
+++ b/data/102/535/679/102535679.geojson
@@ -52,8 +52,10 @@
         "state_id":2346579
     },
     "wof:belongsto":[
-        85633735,
-        85687423
+        85687423,
+        102191581,
+        1511683449,
+        85633735
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -68,14 +70,18 @@
     "wof:hierarchy":[
         {
             "campus_id":102535679,
+            "continent_id":102191581,
             "country_id":85633735,
+            "localadmin_id":1511683449,
+            "locality_id":-1,
+            "neighbourhood_id":-1,
             "region_id":85687423
         }
     ],
     "wof:id":102535679,
-    "wof:lastmodified":1566655389,
+    "wof:lastmodified":1579720769,
     "wof:name":"Vila Real Airport",
-    "wof:parent_id":85687423,
+    "wof:parent_id":1511683449,
     "wof:placetype":"campus",
     "wof:repo":"whosonfirst-data-admin-xy",
     "wof:superseded_by":[],

--- a/data/102/535/681/102535681.geojson
+++ b/data/102/535/681/102535681.geojson
@@ -108,10 +108,10 @@
         "state_id":2346575
     },
     "wof:belongsto":[
+        85687411,
         102191581,
-        85633735,
-        101759307,
-        85687411
+        1511683367,
+        85633735
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -129,14 +129,16 @@
             "campus_id":102535681,
             "continent_id":102191581,
             "country_id":85633735,
-            "locality_id":101759307,
+            "localadmin_id":1511683367,
+            "locality_id":-1,
+            "neighbourhood_id":-1,
             "region_id":85687411
         }
     ],
     "wof:id":102535681,
-    "wof:lastmodified":1566655351,
+    "wof:lastmodified":1579720768,
     "wof:name":"Francisco Sa Carneiro Airport",
-    "wof:parent_id":101759307,
+    "wof:parent_id":1511683367,
     "wof:placetype":"campus",
     "wof:repo":"whosonfirst-data-admin-xy",
     "wof:superseded_by":[],

--- a/data/102/535/683/102535683.geojson
+++ b/data/102/535/683/102535683.geojson
@@ -53,8 +53,10 @@
         "state_id":2346580
     },
     "wof:belongsto":[
-        85633735,
-        85687401
+        85687401,
+        102191581,
+        1511682515,
+        85633735
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -69,14 +71,18 @@
     "wof:hierarchy":[
         {
             "campus_id":102535683,
+            "continent_id":102191581,
             "country_id":85633735,
+            "localadmin_id":1511682515,
+            "locality_id":-1,
+            "neighbourhood_id":-1,
             "region_id":85687401
         }
     ],
     "wof:id":102535683,
-    "wof:lastmodified":1566655390,
+    "wof:lastmodified":1579720767,
     "wof:name":"Viseu Airport",
-    "wof:parent_id":85687401,
+    "wof:parent_id":1511682515,
     "wof:placetype":"campus",
     "wof:repo":"whosonfirst-data-admin-xy",
     "wof:superseded_by":[],

--- a/data/102/535/687/102535687.geojson
+++ b/data/102/535/687/102535687.geojson
@@ -82,8 +82,10 @@
         "state_id":15021776
     },
     "wof:belongsto":[
-        85633735,
-        85687465
+        1511614891,
+        102191581,
+        1511685471,
+        85633735
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -95,14 +97,18 @@
     "wof:hierarchy":[
         {
             "campus_id":102535687,
+            "continent_id":102191581,
             "country_id":85633735,
-            "region_id":85687465
+            "localadmin_id":1511685471,
+            "locality_id":-1,
+            "neighbourhood_id":-1,
+            "region_id":1511614891
         }
     ],
     "wof:id":102535687,
-    "wof:lastmodified":1566655357,
+    "wof:lastmodified":1579720769,
     "wof:name":"Flores Airport",
-    "wof:parent_id":85687465,
+    "wof:parent_id":1511685471,
     "wof:placetype":"campus",
     "wof:repo":"whosonfirst-data-admin-xy",
     "wof:superseded_by":[],

--- a/data/102/535/689/102535689.geojson
+++ b/data/102/535/689/102535689.geojson
@@ -67,9 +67,10 @@
         "state_id":15021776
     },
     "wof:belongsto":[
-        85633735,
-        101849997,
-        85687441
+        1511614891,
+        102191581,
+        1511685275,
+        85633735
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -85,15 +86,18 @@
     "wof:hierarchy":[
         {
             "campus_id":102535689,
+            "continent_id":102191581,
             "country_id":85633735,
-            "locality_id":101849997,
-            "region_id":85687441
+            "localadmin_id":1511685275,
+            "locality_id":-1,
+            "neighbourhood_id":-1,
+            "region_id":1511614891
         }
     ],
     "wof:id":102535689,
-    "wof:lastmodified":1566655355,
+    "wof:lastmodified":1579720768,
     "wof:name":"Lajes Airport",
-    "wof:parent_id":101849997,
+    "wof:parent_id":1511685275,
     "wof:placetype":"campus",
     "wof:repo":"whosonfirst-data-admin-xy",
     "wof:superseded_by":[],

--- a/data/102/535/693/102535693.geojson
+++ b/data/102/535/693/102535693.geojson
@@ -84,8 +84,10 @@
         "state_id":15021776
     },
     "wof:belongsto":[
-        85633735,
-        85687455
+        1511614891,
+        102191581,
+        1511685181,
+        85633735
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -101,14 +103,18 @@
     "wof:hierarchy":[
         {
             "campus_id":102535693,
+            "continent_id":102191581,
             "country_id":85633735,
-            "region_id":85687455
+            "localadmin_id":1511685181,
+            "locality_id":-1,
+            "neighbourhood_id":-1,
+            "region_id":1511614891
         }
     ],
     "wof:id":102535693,
-    "wof:lastmodified":1566655362,
+    "wof:lastmodified":1579720770,
     "wof:name":"Aeroporto da Horta",
-    "wof:parent_id":85687455,
+    "wof:parent_id":1511685181,
     "wof:placetype":"campus",
     "wof:repo":"whosonfirst-data-admin-xy",
     "wof:superseded_by":[],

--- a/data/102/535/697/102535697.geojson
+++ b/data/102/535/697/102535697.geojson
@@ -64,8 +64,10 @@
         "state_id":15021776
     },
     "wof:belongsto":[
-        85633735,
-        85687447
+        1511614891,
+        102191581,
+        1511685173,
+        85633735
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -81,14 +83,18 @@
     "wof:hierarchy":[
         {
             "campus_id":102535697,
+            "continent_id":102191581,
             "country_id":85633735,
-            "region_id":85687447
+            "localadmin_id":1511685173,
+            "locality_id":-1,
+            "neighbourhood_id":-1,
+            "region_id":1511614891
         }
     ],
     "wof:id":102535697,
-    "wof:lastmodified":1566655392,
+    "wof:lastmodified":1579720768,
     "wof:name":"Aeroporto da Ilha do Pico",
-    "wof:parent_id":85687447,
+    "wof:parent_id":1511685173,
     "wof:placetype":"campus",
     "wof:repo":"whosonfirst-data-admin-xy",
     "wof:superseded_by":[],

--- a/data/102/535/703/102535703.geojson
+++ b/data/102/535/703/102535703.geojson
@@ -108,10 +108,10 @@
         "state_id":15021776
     },
     "wof:belongsto":[
+        1511614891,
         102191581,
-        85633735,
-        101849933,
-        85687437
+        1511685317,
+        85633735
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -129,14 +129,16 @@
             "campus_id":102535703,
             "continent_id":102191581,
             "country_id":85633735,
-            "locality_id":101849933,
-            "region_id":85687437
+            "localadmin_id":1511685317,
+            "locality_id":-1,
+            "neighbourhood_id":-1,
+            "region_id":1511614891
         }
     ],
     "wof:id":102535703,
-    "wof:lastmodified":1566655379,
+    "wof:lastmodified":1579720769,
     "wof:name":"Ponta Delgada Airport",
-    "wof:parent_id":101849933,
+    "wof:parent_id":1511685317,
     "wof:placetype":"campus",
     "wof:repo":"whosonfirst-data-admin-xy",
     "wof:superseded_by":[],

--- a/data/102/535/707/102535707.geojson
+++ b/data/102/535/707/102535707.geojson
@@ -61,8 +61,10 @@
         "state_id":15021776
     },
     "wof:belongsto":[
-        85633735,
-        85687451
+        1511614891,
+        102191581,
+        1511685631,
+        85633735
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -78,14 +80,18 @@
     "wof:hierarchy":[
         {
             "campus_id":102535707,
+            "continent_id":102191581,
             "country_id":85633735,
-            "region_id":85687451
+            "localadmin_id":1511685631,
+            "locality_id":-1,
+            "neighbourhood_id":-1,
+            "region_id":1511614891
         }
     ],
     "wof:id":102535707,
-    "wof:lastmodified":1566655350,
+    "wof:lastmodified":1579720768,
     "wof:name":"Aeroporto da Ilha de S\u00e3o Jorge",
-    "wof:parent_id":85687451,
+    "wof:parent_id":1511685631,
     "wof:placetype":"campus",
     "wof:repo":"whosonfirst-data-admin-xy",
     "wof:superseded_by":[],

--- a/data/102/535/715/102535715.geojson
+++ b/data/102/535/715/102535715.geojson
@@ -67,8 +67,10 @@
         "state_id":15021776
     },
     "wof:belongsto":[
-        85633735,
-        85687459
+        1511614891,
+        102191581,
+        1511685607,
+        85633735
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -84,14 +86,18 @@
     "wof:hierarchy":[
         {
             "campus_id":102535715,
+            "continent_id":102191581,
             "country_id":85633735,
-            "region_id":85687459
+            "localadmin_id":1511685607,
+            "locality_id":-1,
+            "neighbourhood_id":-1,
+            "region_id":1511614891
         }
     ],
     "wof:id":102535715,
-    "wof:lastmodified":1566655370,
+    "wof:lastmodified":1579720770,
     "wof:name":"Aer\u00f3dromo da Graciosa",
-    "wof:parent_id":85687459,
+    "wof:parent_id":1511685607,
     "wof:placetype":"campus",
     "wof:repo":"whosonfirst-data-admin-xy",
     "wof:superseded_by":[],

--- a/data/102/535/717/102535717.geojson
+++ b/data/102/535/717/102535717.geojson
@@ -77,8 +77,10 @@
         "state_id":15021776
     },
     "wof:belongsto":[
-        85633735,
-        85687429
+        1511614891,
+        102191581,
+        1511685305,
+        85633735
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -94,14 +96,18 @@
     "wof:hierarchy":[
         {
             "campus_id":102535717,
+            "continent_id":102191581,
             "country_id":85633735,
-            "region_id":85687429
+            "localadmin_id":1511685305,
+            "locality_id":-1,
+            "neighbourhood_id":-1,
+            "region_id":1511614891
         }
     ],
     "wof:id":102535717,
-    "wof:lastmodified":1566655403,
+    "wof:lastmodified":1579720767,
     "wof:name":"Santa Maria Airport",
-    "wof:parent_id":85687429,
+    "wof:parent_id":1511685305,
     "wof:placetype":"campus",
     "wof:repo":"whosonfirst-data-admin-xy",
     "wof:superseded_by":[],

--- a/data/102/535/719/102535719.geojson
+++ b/data/102/535/719/102535719.geojson
@@ -27,9 +27,10 @@
         "state_id":2346570
     },
     "wof:belongsto":[
+        1511614893,
         102191581,
-        85633735,
-        85687345
+        1511685539,
+        85633735
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -42,15 +43,16 @@
             "campus_id":102535719,
             "continent_id":102191581,
             "country_id":85633735,
+            "localadmin_id":1511685539,
             "locality_id":-1,
             "neighbourhood_id":-1,
-            "region_id":85687345
+            "region_id":1511614893
         }
     ],
     "wof:id":102535719,
-    "wof:lastmodified":1566655402,
+    "wof:lastmodified":1579720768,
     "wof:name":"Aeroporto da Madeira",
-    "wof:parent_id":-1,
+    "wof:parent_id":1511685539,
     "wof:placetype":"campus",
     "wof:repo":"whosonfirst-data-admin-xy",
     "wof:superseded_by":[],

--- a/data/102/544/777/102544777.geojson
+++ b/data/102/544/777/102544777.geojson
@@ -51,6 +51,7 @@
         102191577,
         404565997,
         85633009,
+        1511777409,
         102060179
     ],
     "wof:breaches":[],
@@ -70,11 +71,14 @@
             "country_id":85633009,
             "county_id":102060179,
             "localadmin_id":404565997,
+            "locality_id":-1,
+            "macroregion_id":1511777409,
+            "neighbourhood_id":-1,
             "region_id":85682021
         }
     ],
     "wof:id":102544777,
-    "wof:lastmodified":1566655957,
+    "wof:lastmodified":1577829513,
     "wof:name":"Branches Airport",
     "wof:parent_id":404565997,
     "wof:placetype":"campus",

--- a/data/102/551/609/102551609.geojson
+++ b/data/102/551/609/102551609.geojson
@@ -31,6 +31,7 @@
         85681959,
         102191577,
         85633009,
+        1511777407,
         101942177,
         102055967
     ],
@@ -50,11 +51,13 @@
             "country_id":85633009,
             "county_id":102055967,
             "locality_id":101942177,
+            "macroregion_id":1511777407,
+            "neighbourhood_id":-1,
             "region_id":85681959
         }
     ],
     "wof:id":102551609,
-    "wof:lastmodified":1566654967,
+    "wof:lastmodified":1577826463,
     "wof:name":"Tuzla Airport",
     "wof:parent_id":101942177,
     "wof:placetype":"campus",

--- a/data/102/551/659/102551659.geojson
+++ b/data/102/551/659/102551659.geojson
@@ -51,6 +51,7 @@
         102191577,
         404562301,
         85633009,
+        1511777411,
         101953801,
         102058377
     ],
@@ -73,11 +74,13 @@
             "county_id":102058377,
             "localadmin_id":404562301,
             "locality_id":101953801,
+            "macroregion_id":1511777411,
+            "neighbourhood_id":-1,
             "region_id":85681991
         }
     ],
     "wof:id":102551659,
-    "wof:lastmodified":1566654931,
+    "wof:lastmodified":1577835056,
     "wof:name":"Itaipu Airport",
     "wof:parent_id":101953801,
     "wof:placetype":"campus",

--- a/data/102/554/591/102554591.geojson
+++ b/data/102/554/591/102554591.geojson
@@ -43,6 +43,9 @@
         "gp:id":12511918
     },
     "wof:country":"",
+    "wof:geom_alt":[
+        "woedb"
+    ],
     "wof:geomhash":"b3bac8765858da050429274c809da39a",
     "wof:hierarchy":[
         {
@@ -57,7 +60,7 @@
         }
     ],
     "wof:id":102554591,
-    "wof:lastmodified":1566656733,
+    "wof:lastmodified":1582332141,
     "wof:name":"Winnipeg International Airport",
     "wof:parent_id":1108969787,
     "wof:placetype":"campus",

--- a/data/102/556/567/102556567.geojson
+++ b/data/102/556/567/102556567.geojson
@@ -83,10 +83,10 @@
         "state_id":2346388
     },
     "wof:belongsto":[
+        1527947259,
         102191581,
         1159297127,
-        85633341,
-        85687145
+        85633341
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -107,11 +107,11 @@
             "localadmin_id":1159297127,
             "locality_id":-1,
             "neighbourhood_id":-1,
-            "region_id":85687145
+            "region_id":1527947259
         }
     ],
     "wof:id":102556567,
-    "wof:lastmodified":1566654978,
+    "wof:lastmodified":1581017528,
     "wof:name":"Vard\u00f8 lufthavn Svartnes",
     "wof:parent_id":1159297127,
     "wof:placetype":"campus",

--- a/data/102/556/569/102556569.geojson
+++ b/data/102/556/569/102556569.geojson
@@ -80,8 +80,10 @@
         "state_id":2346392
     },
     "wof:belongsto":[
+        85687135,
+        102191581,
         1159296877,
-        85687135
+        85633341
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -97,8 +99,8 @@
     "wof:hierarchy":[
         {
             "campus_id":102556569,
-            "continent_id":-1,
-            "country_id":-1,
+            "continent_id":102191581,
+            "country_id":85633341,
             "localadmin_id":1159296877,
             "locality_id":-1,
             "neighbourhood_id":-1,
@@ -106,7 +108,7 @@
         }
     ],
     "wof:id":102556569,
-    "wof:lastmodified":1566654978,
+    "wof:lastmodified":1580779929,
     "wof:name":"Mosj\u00f8en lufthavn Kj\u00e6rstad",
     "wof:parent_id":1159296877,
     "wof:placetype":"campus",

--- a/data/102/556/571/102556571.geojson
+++ b/data/102/556/571/102556571.geojson
@@ -82,10 +82,10 @@
         "state_id":2346398
     },
     "wof:belongsto":[
+        1527947261,
         102191581,
-        1159297581,
-        85633341,
-        85687113
+        1527971041,
+        85633341
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -102,16 +102,16 @@
             "campus_id":102556571,
             "continent_id":102191581,
             "country_id":85633341,
-            "localadmin_id":1159297581,
+            "localadmin_id":1527971041,
             "locality_id":-1,
             "neighbourhood_id":-1,
-            "region_id":85687113
+            "region_id":1527947261
         }
     ],
     "wof:id":102556571,
-    "wof:lastmodified":1566655034,
+    "wof:lastmodified":1580873798,
     "wof:name":"Sogndal lufthamn Hauk\u00e5sen",
-    "wof:parent_id":1159297581,
+    "wof:parent_id":1527971041,
     "wof:placetype":"campus",
     "wof:repo":"whosonfirst-data-admin-xy",
     "wof:superseded_by":[],

--- a/data/102/556/577/102556577.geojson
+++ b/data/102/556/577/102556577.geojson
@@ -80,8 +80,10 @@
         "state_id":2346392
     },
     "wof:belongsto":[
+        85687135,
+        102191581,
         1159296963,
-        85687135
+        85633341
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -97,8 +99,8 @@
     "wof:hierarchy":[
         {
             "campus_id":102556577,
-            "continent_id":-1,
-            "country_id":-1,
+            "continent_id":102191581,
+            "country_id":85633341,
             "localadmin_id":1159296963,
             "locality_id":-1,
             "neighbourhood_id":-1,
@@ -106,7 +108,7 @@
         }
     ],
     "wof:id":102556577,
-    "wof:lastmodified":1566655040,
+    "wof:lastmodified":1580779929,
     "wof:name":"Mo I Rana Lufthavn Rossvoll",
     "wof:parent_id":1159296963,
     "wof:placetype":"campus",

--- a/data/102/556/579/102556579.geojson
+++ b/data/102/556/579/102556579.geojson
@@ -59,10 +59,10 @@
         "state_id":2346387
     },
     "wof:belongsto":[
+        1527947269,
         102191581,
         1159297373,
-        85633341,
-        85687105
+        85633341
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -83,11 +83,11 @@
             "localadmin_id":1159297373,
             "locality_id":-1,
             "neighbourhood_id":-1,
-            "region_id":85687105
+            "region_id":1527947269
         }
     ],
     "wof:id":102556579,
-    "wof:lastmodified":1566655039,
+    "wof:lastmodified":1580875830,
     "wof:name":"Gol flyplass Klanten",
     "wof:parent_id":1159297373,
     "wof:placetype":"campus",

--- a/data/102/556/581/102556581.geojson
+++ b/data/102/556/581/102556581.geojson
@@ -85,9 +85,11 @@
         "state_id":2346392
     },
     "wof:belongsto":[
+        85687135,
+        102191581,
         1159297445,
-        101814647,
-        85687135
+        85633341,
+        101814647
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -103,8 +105,8 @@
     "wof:hierarchy":[
         {
             "campus_id":102556581,
-            "continent_id":-1,
-            "country_id":-1,
+            "continent_id":102191581,
+            "country_id":85633341,
             "localadmin_id":1159297445,
             "locality_id":101814647,
             "neighbourhood_id":-1,
@@ -112,7 +114,7 @@
         }
     ],
     "wof:id":102556581,
-    "wof:lastmodified":1566655005,
+    "wof:lastmodified":1581028680,
     "wof:name":"Br\u00f8nn\u00f8ysund Lufthavn",
     "wof:parent_id":101814647,
     "wof:placetype":"campus",

--- a/data/102/556/583/102556583.geojson
+++ b/data/102/556/583/102556583.geojson
@@ -59,11 +59,11 @@
         "state_id":2346389
     },
     "wof:belongsto":[
+        1527947263,
         102191581,
         1159297089,
         85633341,
-        101815625,
-        85687117
+        1495124017
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -82,15 +82,15 @@
             "continent_id":102191581,
             "country_id":85633341,
             "localadmin_id":1159297089,
-            "locality_id":101815625,
+            "locality_id":1495124017,
             "neighbourhood_id":-1,
-            "region_id":85687117
+            "region_id":1527947263
         }
     ],
     "wof:id":102556583,
-    "wof:lastmodified":1566655040,
+    "wof:lastmodified":1580874197,
     "wof:name":"Hamar flyplass Stafsberg",
-    "wof:parent_id":101815625,
+    "wof:parent_id":1495124017,
     "wof:placetype":"campus",
     "wof:repo":"whosonfirst-data-admin-xy",
     "wof:superseded_by":[],

--- a/data/102/556/585/102556585.geojson
+++ b/data/102/556/585/102556585.geojson
@@ -76,9 +76,11 @@
         "state_id":2346392
     },
     "wof:belongsto":[
+        85687135,
+        102191581,
         1159297039,
-        101814609,
-        85687135
+        85633341,
+        101814609
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -94,8 +96,8 @@
     "wof:hierarchy":[
         {
             "campus_id":102556585,
-            "continent_id":-1,
-            "country_id":-1,
+            "continent_id":102191581,
+            "country_id":85633341,
             "localadmin_id":1159297039,
             "locality_id":101814609,
             "neighbourhood_id":-1,
@@ -103,7 +105,7 @@
         }
     ],
     "wof:id":102556585,
-    "wof:lastmodified":1566655035,
+    "wof:lastmodified":1580779929,
     "wof:name":"Leknes Lufthavn",
     "wof:parent_id":101814609,
     "wof:placetype":"campus",

--- a/data/102/556/587/102556587.geojson
+++ b/data/102/556/587/102556587.geojson
@@ -70,10 +70,10 @@
         "state_id":2346388
     },
     "wof:belongsto":[
+        1527947259,
         102191581,
         1159297403,
-        85633341,
-        85687145
+        85633341
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -93,11 +93,11 @@
             "localadmin_id":1159297403,
             "locality_id":-1,
             "neighbourhood_id":-1,
-            "region_id":85687145
+            "region_id":1527947259
         }
     ],
     "wof:id":102556587,
-    "wof:lastmodified":1566655010,
+    "wof:lastmodified":1580872959,
     "wof:name":"Mehamn lufthavn",
     "wof:parent_id":1159297403,
     "wof:placetype":"campus",

--- a/data/102/556/589/102556589.geojson
+++ b/data/102/556/589/102556589.geojson
@@ -91,10 +91,10 @@
         "state_id":2346388
     },
     "wof:belongsto":[
+        1527947259,
         102191581,
         1159297427,
-        85633341,
-        85687145
+        85633341
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -114,11 +114,11 @@
             "localadmin_id":1159297427,
             "locality_id":-1,
             "neighbourhood_id":-1,
-            "region_id":85687145
+            "region_id":1527947259
         }
     ],
     "wof:id":102556589,
-    "wof:lastmodified":1566655009,
+    "wof:lastmodified":1580872958,
     "wof:name":"Berlev\u00e5g Lufthavn",
     "wof:parent_id":1159297427,
     "wof:placetype":"campus",

--- a/data/102/556/591/102556591.geojson
+++ b/data/102/556/591/102556591.geojson
@@ -58,8 +58,10 @@
         "state_id":2346392
     },
     "wof:belongsto":[
+        85687135,
+        102191581,
         1159297081,
-        85687135
+        85633341
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -75,8 +77,8 @@
     "wof:hierarchy":[
         {
             "campus_id":102556591,
-            "continent_id":-1,
-            "country_id":-1,
+            "continent_id":102191581,
+            "country_id":85633341,
             "localadmin_id":1159297081,
             "locality_id":-1,
             "neighbourhood_id":-1,
@@ -84,7 +86,7 @@
         }
     ],
     "wof:id":102556591,
-    "wof:lastmodified":1566655016,
+    "wof:lastmodified":1581028680,
     "wof:name":"V\u00e6r\u00f8y flyplass",
     "wof:parent_id":1159297081,
     "wof:placetype":"campus",

--- a/data/102/556/595/102556595.geojson
+++ b/data/102/556/595/102556595.geojson
@@ -80,10 +80,10 @@
         "state_id":2346397
     },
     "wof:belongsto":[
+        1527947261,
         102191581,
         1159297369,
-        85633341,
-        85687099
+        85633341
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -104,11 +104,11 @@
             "localadmin_id":1159297369,
             "locality_id":-1,
             "neighbourhood_id":-1,
-            "region_id":85687099
+            "region_id":1527947261
         }
     ],
     "wof:id":102556595,
-    "wof:lastmodified":1566654981,
+    "wof:lastmodified":1580873798,
     "wof:name":"Stord lufthavn S\u00f8rstokken",
     "wof:parent_id":1159297369,
     "wof:placetype":"campus",

--- a/data/102/556/601/102556601.geojson
+++ b/data/102/556/601/102556601.geojson
@@ -83,10 +83,10 @@
         "state_id":2346393
     },
     "wof:belongsto":[
+        1495115971,
         102191581,
-        1159296895,
-        85633341,
-        85687133
+        1527971119,
+        85633341
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -104,16 +104,16 @@
             "campus_id":102556601,
             "continent_id":102191581,
             "country_id":85633341,
-            "localadmin_id":1159296895,
+            "localadmin_id":1527971119,
             "locality_id":-1,
             "neighbourhood_id":-1,
-            "region_id":85687133
+            "region_id":1495115971
         }
     ],
     "wof:id":102556601,
-    "wof:lastmodified":1566655030,
+    "wof:lastmodified":1580774529,
     "wof:name":"R\u00f8rvik lufthavn Ryum",
-    "wof:parent_id":1159296895,
+    "wof:parent_id":1527971119,
     "wof:placetype":"campus",
     "wof:repo":"whosonfirst-data-admin-xy",
     "wof:superseded_by":[],

--- a/data/102/556/603/102556603.geojson
+++ b/data/102/556/603/102556603.geojson
@@ -81,11 +81,11 @@
         "state_id":2346398
     },
     "wof:belongsto":[
+        1527947261,
         102191581,
-        1159297017,
+        1527971009,
         85633341,
-        101804023,
-        85687113
+        101804023
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -99,14 +99,14 @@
             "campus_id":102556603,
             "continent_id":102191581,
             "country_id":85633341,
-            "localadmin_id":1159297017,
+            "localadmin_id":1527971009,
             "locality_id":101804023,
             "neighbourhood_id":-1,
-            "region_id":85687113
+            "region_id":1527947261
         }
     ],
     "wof:id":102556603,
-    "wof:lastmodified":1566654998,
+    "wof:lastmodified":1580873798,
     "wof:name":"Flor\u00f8 Lufthavn",
     "wof:parent_id":101804023,
     "wof:placetype":"campus",

--- a/data/102/556/605/102556605.geojson
+++ b/data/102/556/605/102556605.geojson
@@ -76,10 +76,10 @@
         "state_id":2346388
     },
     "wof:belongsto":[
+        1527947259,
         102191581,
         1159296899,
-        85633341,
-        85687145
+        85633341
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -100,11 +100,11 @@
             "localadmin_id":1159296899,
             "locality_id":-1,
             "neighbourhood_id":-1,
-            "region_id":85687145
+            "region_id":1527947259
         }
     ],
     "wof:id":102556605,
-    "wof:lastmodified":1566654994,
+    "wof:lastmodified":1581017529,
     "wof:name":"Hasvik lufthavn",
     "wof:parent_id":1159296899,
     "wof:placetype":"campus",

--- a/data/102/556/609/102556609.geojson
+++ b/data/102/556/609/102556609.geojson
@@ -82,8 +82,10 @@
         "state_id":2346392
     },
     "wof:belongsto":[
+        85687135,
+        102191581,
         1159296803,
-        85687135
+        85633341
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -99,8 +101,8 @@
     "wof:hierarchy":[
         {
             "campus_id":102556609,
-            "continent_id":-1,
-            "country_id":-1,
+            "continent_id":102191581,
+            "country_id":85633341,
             "localadmin_id":1159296803,
             "locality_id":-1,
             "neighbourhood_id":-1,
@@ -108,7 +110,7 @@
         }
     ],
     "wof:id":102556609,
-    "wof:lastmodified":1566655034,
+    "wof:lastmodified":1581028679,
     "wof:name":"R\u00f8st lufthavn",
     "wof:parent_id":1159296803,
     "wof:placetype":"campus",

--- a/data/102/556/615/102556615.geojson
+++ b/data/102/556/615/102556615.geojson
@@ -80,8 +80,10 @@
         "state_id":2346392
     },
     "wof:belongsto":[
+        85687135,
+        102191581,
         1159297007,
-        85687135
+        85633341
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -97,8 +99,8 @@
     "wof:hierarchy":[
         {
             "campus_id":102556615,
-            "continent_id":-1,
-            "country_id":-1,
+            "continent_id":102191581,
+            "country_id":85633341,
             "localadmin_id":1159297007,
             "locality_id":-1,
             "neighbourhood_id":-1,
@@ -106,7 +108,7 @@
         }
     ],
     "wof:id":102556615,
-    "wof:lastmodified":1566655024,
+    "wof:lastmodified":1580779930,
     "wof:name":"Sandnessj\u00f8en Lufthavn Stokka",
     "wof:parent_id":1159297007,
     "wof:placetype":"campus",

--- a/data/102/556/617/102556617.geojson
+++ b/data/102/556/617/102556617.geojson
@@ -81,10 +81,10 @@
         "state_id":2346388
     },
     "wof:belongsto":[
+        1527947259,
         102191581,
-        1159296825,
-        85633341,
-        85687145
+        1527971095,
+        85633341
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -98,16 +98,16 @@
             "campus_id":102556617,
             "continent_id":102191581,
             "country_id":85633341,
-            "localadmin_id":1159296825,
+            "localadmin_id":1527971095,
             "locality_id":-1,
             "neighbourhood_id":-1,
-            "region_id":85687145
+            "region_id":1527947259
         }
     ],
     "wof:id":102556617,
-    "wof:lastmodified":1566654987,
+    "wof:lastmodified":1580872959,
     "wof:name":"Hammerfest Lufthavn",
-    "wof:parent_id":1159296825,
+    "wof:parent_id":1527971095,
     "wof:placetype":"campus",
     "wof:repo":"whosonfirst-data-admin-xy",
     "wof:superseded_by":[],

--- a/data/102/556/619/102556619.geojson
+++ b/data/102/556/619/102556619.geojson
@@ -88,10 +88,10 @@
         "state_id":2346388
     },
     "wof:belongsto":[
+        1527947259,
         102191581,
         1159297387,
-        85633341,
-        85687145
+        85633341
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -111,11 +111,11 @@
             "localadmin_id":1159297387,
             "locality_id":-1,
             "neighbourhood_id":-1,
-            "region_id":85687145
+            "region_id":1527947259
         }
     ],
     "wof:id":102556619,
-    "wof:lastmodified":1566654988,
+    "wof:lastmodified":1580872959,
     "wof:name":"Vads\u00f8 lufthavn",
     "wof:parent_id":1159297387,
     "wof:placetype":"campus",

--- a/data/102/556/621/102556621.geojson
+++ b/data/102/556/621/102556621.geojson
@@ -79,11 +79,11 @@
         "state_id":2346401
     },
     "wof:belongsto":[
+        1527947259,
         102191581,
         1159297593,
         85633341,
-        101814677,
-        85687143
+        101814677
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -104,11 +104,11 @@
             "localadmin_id":1159297593,
             "locality_id":101814677,
             "neighbourhood_id":-1,
-            "region_id":85687143
+            "region_id":1527947259
         }
     ],
     "wof:id":102556621,
-    "wof:lastmodified":1566654987,
+    "wof:lastmodified":1580872958,
     "wof:name":"S\u00f8rkjosen lufthavn",
     "wof:parent_id":101814677,
     "wof:placetype":"campus",

--- a/data/102/556/623/102556623.geojson
+++ b/data/102/556/623/102556623.geojson
@@ -91,10 +91,10 @@
         "state_id":2346388
     },
     "wof:belongsto":[
+        1527947259,
         102191581,
         1159297303,
-        85633341,
-        85687145
+        85633341
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -115,11 +115,11 @@
             "localadmin_id":1159297303,
             "locality_id":-1,
             "neighbourhood_id":-1,
-            "region_id":85687145
+            "region_id":1527947259
         }
     ],
     "wof:id":102556623,
-    "wof:lastmodified":1566655022,
+    "wof:lastmodified":1580872958,
     "wof:name":"B\u00e5tsfjord Lufthavn",
     "wof:parent_id":1159297303,
     "wof:placetype":"campus",

--- a/data/102/556/625/102556625.geojson
+++ b/data/102/556/625/102556625.geojson
@@ -85,10 +85,10 @@
         "state_id":2346391
     },
     "wof:belongsto":[
+        85687123,
         102191581,
-        1159297435,
-        85633341,
-        85687123
+        1527971087,
+        85633341
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -106,16 +106,16 @@
             "campus_id":102556625,
             "continent_id":102191581,
             "country_id":85633341,
-            "localadmin_id":1159297435,
+            "localadmin_id":1527971087,
             "locality_id":-1,
             "neighbourhood_id":-1,
             "region_id":85687123
         }
     ],
     "wof:id":102556625,
-    "wof:lastmodified":1566655018,
+    "wof:lastmodified":1580774218,
     "wof:name":"\u00d6rsta Volda Lufthavn",
-    "wof:parent_id":1159297435,
+    "wof:parent_id":1527971087,
     "wof:placetype":"campus",
     "wof:repo":"whosonfirst-data-admin-xy",
     "wof:superseded_by":[],

--- a/data/102/556/627/102556627.geojson
+++ b/data/102/556/627/102556627.geojson
@@ -79,10 +79,10 @@
         "state_id":2346393
     },
     "wof:belongsto":[
+        1495115971,
         102191581,
-        1159297197,
-        85633341,
-        85687133
+        1527971015,
+        85633341
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -100,16 +100,16 @@
             "campus_id":102556627,
             "continent_id":102191581,
             "country_id":85633341,
-            "localadmin_id":1159297197,
+            "localadmin_id":1527971015,
             "locality_id":-1,
             "neighbourhood_id":-1,
-            "region_id":85687133
+            "region_id":1495115971
         }
     ],
     "wof:id":102556627,
-    "wof:lastmodified":1566654991,
+    "wof:lastmodified":1580774529,
     "wof:name":"Namsos lufthavn",
-    "wof:parent_id":1159297197,
+    "wof:parent_id":1527971015,
     "wof:placetype":"campus",
     "wof:repo":"whosonfirst-data-admin-xy",
     "wof:superseded_by":[],

--- a/data/102/556/631/102556631.geojson
+++ b/data/102/556/631/102556631.geojson
@@ -99,11 +99,11 @@
         "state_id":2346388
     },
     "wof:belongsto":[
+        1527947259,
         102191581,
         1159296893,
         85633341,
-        101814717,
-        85687145
+        101814717
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -124,11 +124,11 @@
             "localadmin_id":1159296893,
             "locality_id":101814717,
             "neighbourhood_id":-1,
-            "region_id":85687145
+            "region_id":1527947259
         }
     ],
     "wof:id":102556631,
-    "wof:lastmodified":1566655034,
+    "wof:lastmodified":1580872959,
     "wof:name":"Alta Lufthavn",
     "wof:parent_id":101814717,
     "wof:placetype":"campus",

--- a/data/102/556/633/102556633.geojson
+++ b/data/102/556/633/102556633.geojson
@@ -80,10 +80,10 @@
         "state_id":2346394
     },
     "wof:belongsto":[
+        1527947263,
         102191581,
         1159297391,
-        85633341,
-        85687109
+        85633341
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -104,11 +104,11 @@
             "localadmin_id":1159297391,
             "locality_id":-1,
             "neighbourhood_id":-1,
-            "region_id":85687109
+            "region_id":1527947263
         }
     ],
     "wof:id":102556633,
-    "wof:lastmodified":1566654993,
+    "wof:lastmodified":1580874196,
     "wof:name":"Fagernes Lufthavn Leirin",
     "wof:parent_id":1159297391,
     "wof:placetype":"campus",

--- a/data/102/556/635/102556635.geojson
+++ b/data/102/556/635/102556635.geojson
@@ -40,11 +40,11 @@
         "state_id":2346401
     },
     "wof:belongsto":[
+        1527947259,
         102191581,
         1159296775,
         85633341,
-        101814665,
-        85687143
+        1495123895
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -63,15 +63,15 @@
             "continent_id":102191581,
             "country_id":85633341,
             "localadmin_id":1159296775,
-            "locality_id":101814665,
+            "locality_id":1495123895,
             "neighbourhood_id":-1,
-            "region_id":85687143
+            "region_id":1527947259
         }
     ],
     "wof:id":102556635,
-    "wof:lastmodified":1566654998,
+    "wof:lastmodified":1580872958,
     "wof:name":"Bardufoss Lufthavn",
-    "wof:parent_id":101814665,
+    "wof:parent_id":1495123895,
     "wof:placetype":"campus",
     "wof:repo":"whosonfirst-data-admin-xy",
     "wof:superseded_by":[],

--- a/data/102/556/645/102556645.geojson
+++ b/data/102/556/645/102556645.geojson
@@ -175,10 +175,10 @@
         "state_id":2346385
     },
     "wof:belongsto":[
+        1527947269,
         102191581,
         1159297621,
-        85633341,
-        85687095
+        85633341
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -199,11 +199,11 @@
             "localadmin_id":1159297621,
             "locality_id":-1,
             "neighbourhood_id":-1,
-            "region_id":85687095
+            "region_id":1527947269
         }
     ],
     "wof:id":102556645,
-    "wof:lastmodified":1566654989,
+    "wof:lastmodified":1580875830,
     "wof:name":"Oslo Lufthavn Gardermoen",
     "wof:parent_id":1159297621,
     "wof:placetype":"campus",

--- a/data/102/556/653/102556653.geojson
+++ b/data/102/556/653/102556653.geojson
@@ -106,11 +106,11 @@
         "state_id":2346393
     },
     "wof:belongsto":[
+        1495115971,
         102191581,
         1159296711,
         85633341,
-        101839461,
-        85687133
+        101839461
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -131,11 +131,11 @@
             "localadmin_id":1159296711,
             "locality_id":101839461,
             "neighbourhood_id":-1,
-            "region_id":85687133
+            "region_id":1495115971
         }
     ],
     "wof:id":102556653,
-    "wof:lastmodified":1566655031,
+    "wof:lastmodified":1580774528,
     "wof:name":"Trondheim Lufthavn V\u00e6rnes",
     "wof:parent_id":101839461,
     "wof:placetype":"campus",

--- a/data/102/556/655/102556655.geojson
+++ b/data/102/556/655/102556655.geojson
@@ -58,10 +58,10 @@
         "state_id":2346387
     },
     "wof:belongsto":[
+        1527947269,
         102191581,
         1159297471,
-        85633341,
-        85687105
+        85633341
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -82,11 +82,11 @@
             "localadmin_id":1159297471,
             "locality_id":-1,
             "neighbourhood_id":-1,
-            "region_id":85687105
+            "region_id":1527947269
         }
     ],
     "wof:id":102556655,
-    "wof:lastmodified":1566655026,
+    "wof:lastmodified":1580875830,
     "wof:name":"Geilo Lufthavn",
     "wof:parent_id":1159297471,
     "wof:placetype":"campus",

--- a/data/102/556/659/102556659.geojson
+++ b/data/102/556/659/102556659.geojson
@@ -101,12 +101,7 @@
         "planet_id":1,
         "state_id":2346397
     },
-    "wof:belongsto":[
-        102191581,
-        1159297381,
-        85633341,
-        85687085
-    ],
+    "wof:belongsto":[],
     "wof:breaches":[],
     "wof:concordances":{
         "gp:id":12515124,
@@ -121,18 +116,17 @@
     "wof:hierarchy":[
         {
             "campus_id":102556659,
-            "continent_id":102191581,
-            "country_id":85633341,
-            "localadmin_id":1159297381,
+            "continent_id":-1,
+            "country_id":-1,
             "locality_id":-1,
             "neighbourhood_id":-1,
-            "region_id":85687085
+            "region_id":-1
         }
     ],
     "wof:id":102556659,
-    "wof:lastmodified":1566654999,
+    "wof:lastmodified":1580772308,
     "wof:name":"Stavanger Lufthavn Sola",
-    "wof:parent_id":1159297381,
+    "wof:parent_id":-1,
     "wof:placetype":"campus",
     "wof:repo":"whosonfirst-data-admin-xy",
     "wof:superseded_by":[],

--- a/data/102/556/661/102556661.geojson
+++ b/data/102/556/661/102556661.geojson
@@ -118,10 +118,10 @@
         "state_id":2346403
     },
     "wof:belongsto":[
+        1527947267,
         102191581,
         1159297193,
-        85633341,
-        85687073
+        85633341
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -142,11 +142,11 @@
             "localadmin_id":1159297193,
             "locality_id":-1,
             "neighbourhood_id":-1,
-            "region_id":85687073
+            "region_id":1527947267
         }
     ],
     "wof:id":102556661,
-    "wof:lastmodified":1566655000,
+    "wof:lastmodified":1580875243,
     "wof:name":"Sandfjord Lufthavn Torp",
     "wof:parent_id":1159297193,
     "wof:placetype":"campus",

--- a/data/102/556/663/102556663.geojson
+++ b/data/102/556/663/102556663.geojson
@@ -92,10 +92,10 @@
         "state_id":2346388
     },
     "wof:belongsto":[
+        1527947259,
         102191581,
         1159296947,
-        85633341,
-        85687145
+        85633341
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -116,11 +116,11 @@
             "localadmin_id":1159296947,
             "locality_id":-1,
             "neighbourhood_id":-1,
-            "region_id":85687145
+            "region_id":1527947259
         }
     ],
     "wof:id":102556663,
-    "wof:lastmodified":1566655027,
+    "wof:lastmodified":1580872957,
     "wof:name":"Kirkenes lufthavn H\u00f8ybuktmoen",
     "wof:parent_id":1159296947,
     "wof:placetype":"campus",

--- a/data/102/556/669/102556669.geojson
+++ b/data/102/556/669/102556669.geojson
@@ -108,12 +108,7 @@
         "planet_id":1,
         "state_id":2346401
     },
-    "wof:belongsto":[
-        102191581,
-        1159297187,
-        85633341,
-        85687143
-    ],
+    "wof:belongsto":[],
     "wof:breaches":[],
     "wof:concordances":{
         "gp:id":12515127,
@@ -128,18 +123,17 @@
     "wof:hierarchy":[
         {
             "campus_id":102556669,
-            "continent_id":102191581,
-            "country_id":85633341,
-            "localadmin_id":1159297187,
+            "continent_id":-1,
+            "country_id":-1,
             "locality_id":-1,
             "neighbourhood_id":-1,
-            "region_id":85687143
+            "region_id":-1
         }
     ],
     "wof:id":102556669,
-    "wof:lastmodified":1566654995,
+    "wof:lastmodified":1580780202,
     "wof:name":"Troms\u00f8 lufthavn Langnes",
-    "wof:parent_id":1159297187,
+    "wof:parent_id":-1,
     "wof:placetype":"campus",
     "wof:repo":"whosonfirst-data-admin-xy",
     "wof:superseded_by":[],

--- a/data/102/556/671/102556671.geojson
+++ b/data/102/556/671/102556671.geojson
@@ -87,9 +87,11 @@
         "state_id":2346392
     },
     "wof:belongsto":[
+        85687135,
+        102191581,
         1159297539,
-        101814587,
-        85687135
+        85633341,
+        101814587
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -105,8 +107,8 @@
     "wof:hierarchy":[
         {
             "campus_id":102556671,
-            "continent_id":-1,
-            "country_id":-1,
+            "continent_id":102191581,
+            "country_id":85633341,
             "localadmin_id":1159297539,
             "locality_id":101814587,
             "neighbourhood_id":-1,
@@ -114,7 +116,7 @@
         }
     ],
     "wof:id":102556671,
-    "wof:lastmodified":1566655020,
+    "wof:lastmodified":1581028681,
     "wof:name":"And\u00f8ya Flyplass Andenes",
     "wof:parent_id":101814587,
     "wof:placetype":"campus",

--- a/data/102/556/673/102556673.geojson
+++ b/data/102/556/673/102556673.geojson
@@ -91,10 +91,10 @@
         "state_id":2346391
     },
     "wof:belongsto":[
+        85687123,
         102191581,
         1159297475,
-        85633341,
-        85687123
+        85633341
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -115,7 +115,7 @@
         }
     ],
     "wof:id":102556673,
-    "wof:lastmodified":1566654991,
+    "wof:lastmodified":1581022618,
     "wof:name":"Kristiansund lufthavn Kvernberget",
     "wof:parent_id":1159297475,
     "wof:placetype":"campus",

--- a/data/102/556/681/102556681.geojson
+++ b/data/102/556/681/102556681.geojson
@@ -92,10 +92,10 @@
         "state_id":2346391
     },
     "wof:belongsto":[
+        85687123,
         102191581,
         1159297399,
-        85633341,
-        85687123
+        85633341
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -120,7 +120,7 @@
         }
     ],
     "wof:id":102556681,
-    "wof:lastmodified":1566654986,
+    "wof:lastmodified":1581022618,
     "wof:name":"\u00c5lesund Lufthavn Vigra",
     "wof:parent_id":1159297399,
     "wof:placetype":"campus",

--- a/data/102/556/685/102556685.geojson
+++ b/data/102/556/685/102556685.geojson
@@ -79,8 +79,10 @@
         "state_id":2346399
     },
     "wof:belongsto":[
+        1495115971,
+        102191581,
         1159297133,
-        85687127
+        85633341
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -96,16 +98,16 @@
     "wof:hierarchy":[
         {
             "campus_id":102556685,
-            "continent_id":-1,
-            "country_id":-1,
+            "continent_id":102191581,
+            "country_id":85633341,
             "localadmin_id":1159297133,
             "locality_id":-1,
             "neighbourhood_id":-1,
-            "region_id":85687127
+            "region_id":1495115971
         }
     ],
     "wof:id":102556685,
-    "wof:lastmodified":1566655020,
+    "wof:lastmodified":1580774395,
     "wof:name":"R\u00f8ros lufthavn",
     "wof:parent_id":1159297133,
     "wof:placetype":"campus",

--- a/data/102/556/687/102556687.geojson
+++ b/data/102/556/687/102556687.geojson
@@ -90,10 +90,10 @@
         "state_id":2346402
     },
     "wof:belongsto":[
+        1527947265,
         102191581,
-        1159296703,
-        85633341,
-        85687063
+        1527971063,
+        85633341
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -111,16 +111,16 @@
             "campus_id":102556687,
             "continent_id":102191581,
             "country_id":85633341,
-            "localadmin_id":1159296703,
+            "localadmin_id":1527971063,
             "locality_id":-1,
             "neighbourhood_id":-1,
-            "region_id":85687063
+            "region_id":1527947265
         }
     ],
     "wof:id":102556687,
-    "wof:lastmodified":1566654991,
+    "wof:lastmodified":1580874991,
     "wof:name":"Aeroporto de Kristiansand Kjevik",
-    "wof:parent_id":1159296703,
+    "wof:parent_id":1527971063,
     "wof:placetype":"campus",
     "wof:repo":"whosonfirst-data-admin-xy",
     "wof:superseded_by":[],

--- a/data/102/556/691/102556691.geojson
+++ b/data/102/556/691/102556691.geojson
@@ -93,8 +93,8 @@
         "state_id":2346392
     },
     "wof:belongsto":[
-        1159297465,
-        85687135
+        102191581,
+        85633341
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -110,18 +110,17 @@
     "wof:hierarchy":[
         {
             "campus_id":102556691,
-            "continent_id":-1,
-            "country_id":-1,
-            "localadmin_id":1159297465,
+            "continent_id":102191581,
+            "country_id":85633341,
             "locality_id":-1,
             "neighbourhood_id":-1,
-            "region_id":85687135
+            "region_id":-1
         }
     ],
     "wof:id":102556691,
-    "wof:lastmodified":1566655030,
+    "wof:lastmodified":1580779931,
     "wof:name":"Bod\u00f6 Lufthavn",
-    "wof:parent_id":1159297465,
+    "wof:parent_id":-1,
     "wof:placetype":"campus",
     "wof:repo":"whosonfirst-data-admin-xy",
     "wof:superseded_by":[],

--- a/data/102/556/693/102556693.geojson
+++ b/data/102/556/693/102556693.geojson
@@ -112,11 +112,10 @@
         "state_id":2346390
     },
     "wof:belongsto":[
-        85862273,
+        1527947261,
         102191581,
-        85633341,
-        101751923,
-        85687099
+        1159297617,
+        85633341
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -134,15 +133,16 @@
             "campus_id":102556693,
             "continent_id":102191581,
             "country_id":85633341,
-            "locality_id":101751923,
-            "neighbourhood_id":85862273,
-            "region_id":85687099
+            "localadmin_id":1159297617,
+            "locality_id":-1,
+            "neighbourhood_id":-1,
+            "region_id":1527947261
         }
     ],
     "wof:id":102556693,
-    "wof:lastmodified":1566654996,
+    "wof:lastmodified":1580873797,
     "wof:name":"Bergen Lufthavn Flesland",
-    "wof:parent_id":85862273,
+    "wof:parent_id":1159297617,
     "wof:placetype":"campus",
     "wof:repo":"whosonfirst-data-admin-xy",
     "wof:superseded_by":[],

--- a/data/102/558/605/102558605.geojson
+++ b/data/102/558/605/102558605.geojson
@@ -64,6 +64,7 @@
     "wof:belongsto":[
         102191577,
         85632317,
+        1511838383,
         85680511
     ],
     "wof:breaches":[],
@@ -81,11 +82,14 @@
             "campus_id":102558605,
             "continent_id":102191577,
             "country_id":85632317,
+            "county_id":1511838383,
+            "locality_id":-1,
+            "neighbourhood_id":-1,
             "region_id":85680511
         }
     ],
     "wof:id":102558605,
-    "wof:lastmodified":1566655059,
+    "wof:lastmodified":1578434372,
     "wof:name":"Puerto Ayacucho Airport",
     "wof:parent_id":-1,
     "wof:placetype":"campus",

--- a/data/420/781/683/420781683.geojson
+++ b/data/420/781/683/420781683.geojson
@@ -73,11 +73,11 @@
     ],
     "wd:wordcount":732,
     "wof:belongsto":[
+        85687089,
         102191581,
         1159297167,
         85633341,
-        101751917,
-        85687089
+        1495123997
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -92,15 +92,15 @@
             "continent_id":102191581,
             "country_id":85633341,
             "localadmin_id":1159297167,
-            "locality_id":101751917,
+            "locality_id":1495123997,
             "neighbourhood_id":420781683,
             "region_id":85687089
         }
     ],
     "wof:id":420781683,
-    "wof:lastmodified":1566657541,
+    "wof:lastmodified":1580772638,
     "wof:name":"Gr\u00fcnerl\u00f8kka",
-    "wof:parent_id":101751917,
+    "wof:parent_id":1495123997,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-xy",
     "wof:superseded_by":[],

--- a/data/420/781/685/420781685.geojson
+++ b/data/420/781/685/420781685.geojson
@@ -28,11 +28,11 @@
     ],
     "wd:wordcount":32,
     "wof:belongsto":[
+        85687089,
         102191581,
         1159297167,
         85633341,
-        101751917,
-        85687089
+        1495123997
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -46,15 +46,15 @@
             "continent_id":102191581,
             "country_id":85633341,
             "localadmin_id":1159297167,
-            "locality_id":101751917,
+            "locality_id":1495123997,
             "neighbourhood_id":420781685,
             "region_id":85687089
         }
     ],
     "wof:id":420781685,
-    "wof:lastmodified":1566657538,
+    "wof:lastmodified":1580772638,
     "wof:name":"Kvadraturen",
-    "wof:parent_id":101751917,
+    "wof:parent_id":1495123997,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-xy",
     "wof:superseded_by":[],

--- a/data/420/781/687/420781687.geojson
+++ b/data/420/781/687/420781687.geojson
@@ -61,11 +61,11 @@
     ],
     "wd:wordcount":954,
     "wof:belongsto":[
+        85687089,
         102191581,
         1159297167,
         85633341,
-        101751917,
-        85687089
+        1495123997
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -80,15 +80,15 @@
             "continent_id":102191581,
             "country_id":85633341,
             "localadmin_id":1159297167,
-            "locality_id":101751917,
+            "locality_id":1495123997,
             "neighbourhood_id":420781687,
             "region_id":85687089
         }
     ],
     "wof:id":420781687,
-    "wof:lastmodified":1566657520,
+    "wof:lastmodified":1580772638,
     "wof:name":"Frogner",
-    "wof:parent_id":101751917,
+    "wof:parent_id":1495123997,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-xy",
     "wof:superseded_by":[],

--- a/data/420/781/691/420781691.geojson
+++ b/data/420/781/691/420781691.geojson
@@ -76,11 +76,11 @@
     ],
     "wd:wordcount":183,
     "wof:belongsto":[
+        85687089,
         102191581,
         1159297167,
         85633341,
-        101751917,
-        85687089
+        1495123997
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -95,15 +95,15 @@
             "continent_id":102191581,
             "country_id":85633341,
             "localadmin_id":1159297167,
-            "locality_id":101751917,
+            "locality_id":1495123997,
             "neighbourhood_id":420781691,
             "region_id":85687089
         }
     ],
     "wof:id":420781691,
-    "wof:lastmodified":1566657544,
+    "wof:lastmodified":1580772639,
     "wof:name":"Gamle Oslo",
-    "wof:parent_id":101751917,
+    "wof:parent_id":1495123997,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-xy",
     "wof:superseded_by":[],

--- a/data/420/781/693/420781693.geojson
+++ b/data/420/781/693/420781693.geojson
@@ -27,11 +27,11 @@
         "Veitvet"
     ],
     "wof:belongsto":[
+        85687089,
         102191581,
         1159297167,
         85633341,
-        101751917,
-        85687089
+        1495123997
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -45,15 +45,15 @@
             "continent_id":102191581,
             "country_id":85633341,
             "localadmin_id":1159297167,
-            "locality_id":101751917,
+            "locality_id":1495123997,
             "neighbourhood_id":420781693,
             "region_id":85687089
         }
     ],
     "wof:id":420781693,
-    "wof:lastmodified":1566657523,
+    "wof:lastmodified":1580772638,
     "wof:name":"Veitvet",
-    "wof:parent_id":101751917,
+    "wof:parent_id":1495123997,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-xy",
     "wof:superseded_by":[],

--- a/data/420/783/891/420783891.geojson
+++ b/data/420/783/891/420783891.geojson
@@ -35,8 +35,9 @@
     "wd:wordcount":162,
     "wof:belongsto":[
         102191575,
-        890458845,
         85633041,
+        890458845,
+        1511799789,
         85682091
     ],
     "wof:breaches":[],
@@ -50,13 +51,14 @@
         {
             "continent_id":102191575,
             "country_id":85633041,
+            "county_id":1511799789,
             "locality_id":890458845,
             "neighbourhood_id":420783891,
             "region_id":85682091
         }
     ],
     "wof:id":420783891,
-    "wof:lastmodified":1566657467,
+    "wof:lastmodified":1577998132,
     "wof:name":"Silverado",
     "wof:parent_id":890458845,
     "wof:placetype":"neighbourhood",

--- a/data/420/783/893/420783893.geojson
+++ b/data/420/783/893/420783893.geojson
@@ -38,8 +38,9 @@
     "wd:wordcount":3242,
     "wof:belongsto":[
         102191575,
-        890458845,
         85633041,
+        890458845,
+        1511799789,
         85682091
     ],
     "wof:breaches":[],
@@ -54,13 +55,14 @@
         {
             "continent_id":102191575,
             "country_id":85633041,
+            "county_id":1511799789,
             "locality_id":890458845,
             "neighbourhood_id":420783893,
             "region_id":85682091
         }
     ],
     "wof:id":420783893,
-    "wof:lastmodified":1566657448,
+    "wof:lastmodified":1577998134,
     "wof:name":"Beltline",
     "wof:parent_id":890458845,
     "wof:placetype":"neighbourhood",

--- a/data/420/783/895/420783895.geojson
+++ b/data/420/783/895/420783895.geojson
@@ -29,8 +29,9 @@
     "wd:wordcount":11,
     "wof:belongsto":[
         102191575,
-        890458845,
         85633041,
+        890458845,
+        1511799789,
         85682091
     ],
     "wof:breaches":[],
@@ -44,13 +45,14 @@
         {
             "continent_id":102191575,
             "country_id":85633041,
+            "county_id":1511799789,
             "locality_id":890458845,
             "neighbourhood_id":420783895,
             "region_id":85682091
         }
     ],
     "wof:id":420783895,
-    "wof:lastmodified":1566657443,
+    "wof:lastmodified":1577998131,
     "wof:name":"Mayland",
     "wof:parent_id":890458845,
     "wof:placetype":"neighbourhood",

--- a/data/420/783/897/420783897.geojson
+++ b/data/420/783/897/420783897.geojson
@@ -112,8 +112,9 @@
     ],
     "wof:belongsto":[
         102191575,
-        890458845,
         85633041,
+        890458845,
+        1511799789,
         85682091
     ],
     "wof:breaches":[],
@@ -127,13 +128,14 @@
         {
             "continent_id":102191575,
             "country_id":85633041,
+            "county_id":1511799789,
             "locality_id":890458845,
             "neighbourhood_id":420783897,
             "region_id":85682091
         }
     ],
     "wof:id":420783897,
-    "wof:lastmodified":1566657469,
+    "wof:lastmodified":1577998133,
     "wof:name":"Meridian",
     "wof:parent_id":890458845,
     "wof:placetype":"neighbourhood",

--- a/data/420/783/899/420783899.geojson
+++ b/data/420/783/899/420783899.geojson
@@ -127,8 +127,9 @@
     ],
     "wof:belongsto":[
         102191575,
-        890458845,
         85633041,
+        890458845,
+        1511799789,
         85682091
     ],
     "wof:breaches":[],
@@ -142,13 +143,14 @@
         {
             "continent_id":102191575,
             "country_id":85633041,
+            "county_id":1511799789,
             "locality_id":890458845,
             "neighbourhood_id":420783899,
             "region_id":85682091
         }
     ],
     "wof:id":420783899,
-    "wof:lastmodified":1566657468,
+    "wof:lastmodified":1577998136,
     "wof:name":"Franklin",
     "wof:parent_id":890458845,
     "wof:placetype":"neighbourhood",

--- a/data/420/783/901/420783901.geojson
+++ b/data/420/783/901/420783901.geojson
@@ -25,8 +25,9 @@
     "mz:tier_locality":0,
     "wof:belongsto":[
         102191575,
-        890458845,
         85633041,
+        890458845,
+        1511799789,
         85682091
     ],
     "wof:breaches":[],
@@ -40,13 +41,14 @@
         {
             "continent_id":102191575,
             "country_id":85633041,
+            "county_id":1511799789,
             "locality_id":890458845,
             "neighbourhood_id":420783901,
             "region_id":85682091
         }
     ],
     "wof:id":420783901,
-    "wof:lastmodified":1566657433,
+    "wof:lastmodified":1577998136,
     "wof:name":"South Airways",
     "wof:parent_id":890458845,
     "wof:placetype":"neighbourhood",

--- a/data/420/783/905/420783905.geojson
+++ b/data/420/783/905/420783905.geojson
@@ -47,8 +47,9 @@
     "wd:wordcount":421,
     "wof:belongsto":[
         102191575,
-        890458845,
         85633041,
+        890458845,
+        1511799789,
         85682091
     ],
     "wof:breaches":[],
@@ -62,13 +63,14 @@
         {
             "continent_id":102191575,
             "country_id":85633041,
+            "county_id":1511799789,
             "locality_id":890458845,
             "neighbourhood_id":420783905,
             "region_id":85682091
         }
     ],
     "wof:id":420783905,
-    "wof:lastmodified":1566657458,
+    "wof:lastmodified":1577998132,
     "wof:name":"North Airways",
     "wof:parent_id":890458845,
     "wof:placetype":"neighbourhood",

--- a/data/420/783/907/420783907.geojson
+++ b/data/420/783/907/420783907.geojson
@@ -296,8 +296,9 @@
     "wd:wordcount":3513,
     "wof:belongsto":[
         102191575,
-        890458845,
         85633041,
+        890458845,
+        1511799789,
         85682091
     ],
     "wof:breaches":[],
@@ -312,13 +313,14 @@
         {
             "continent_id":102191575,
             "country_id":85633041,
+            "county_id":1511799789,
             "locality_id":890458845,
             "neighbourhood_id":420783907,
             "region_id":85682091
         }
     ],
     "wof:id":420783907,
-    "wof:lastmodified":1566657431,
+    "wof:lastmodified":1577998135,
     "wof:name":"Horizon",
     "wof:parent_id":890458845,
     "wof:placetype":"neighbourhood",

--- a/data/420/783/909/420783909.geojson
+++ b/data/420/783/909/420783909.geojson
@@ -47,8 +47,9 @@
     "wd:wordcount":249,
     "wof:belongsto":[
         102191575,
-        890458845,
         85633041,
+        890458845,
+        1511799789,
         85682091
     ],
     "wof:breaches":[],
@@ -63,13 +64,14 @@
         {
             "continent_id":102191575,
             "country_id":85633041,
+            "county_id":1511799789,
             "locality_id":890458845,
             "neighbourhood_id":420783909,
             "region_id":85682091
         }
     ],
     "wof:id":420783909,
-    "wof:lastmodified":1566657430,
+    "wof:lastmodified":1577998137,
     "wof:name":"Dalhousie",
     "wof:parent_id":890458845,
     "wof:placetype":"neighbourhood",

--- a/data/420/783/911/420783911.geojson
+++ b/data/420/783/911/420783911.geojson
@@ -25,8 +25,9 @@
     "mz:tier_locality":0,
     "wof:belongsto":[
         102191575,
-        890458845,
         85633041,
+        890458845,
+        1511799789,
         85682091
     ],
     "wof:breaches":[],
@@ -40,13 +41,14 @@
         {
             "continent_id":102191575,
             "country_id":85633041,
+            "county_id":1511799789,
             "locality_id":890458845,
             "neighbourhood_id":420783911,
             "region_id":85682091
         }
     ],
     "wof:id":420783911,
-    "wof:lastmodified":1566657469,
+    "wof:lastmodified":1577998136,
     "wof:name":"Deerfoot Business Centre",
     "wof:parent_id":890458845,
     "wof:placetype":"neighbourhood",

--- a/data/420/783/913/420783913.geojson
+++ b/data/420/783/913/420783913.geojson
@@ -29,8 +29,9 @@
     "wd:wordcount":128,
     "wof:belongsto":[
         102191575,
-        890458845,
         85633041,
+        890458845,
+        1511799789,
         85682091
     ],
     "wof:breaches":[],
@@ -45,13 +46,14 @@
         {
             "continent_id":102191575,
             "country_id":85633041,
+            "county_id":1511799789,
             "locality_id":890458845,
             "neighbourhood_id":420783913,
             "region_id":85682091
         }
     ],
     "wof:id":420783913,
-    "wof:lastmodified":1566657454,
+    "wof:lastmodified":1577998131,
     "wof:name":"University Heights",
     "wof:parent_id":890458845,
     "wof:placetype":"neighbourhood",

--- a/data/420/783/915/420783915.geojson
+++ b/data/420/783/915/420783915.geojson
@@ -32,8 +32,9 @@
     "wd:wordcount":342,
     "wof:belongsto":[
         102191575,
-        890458845,
         85633041,
+        890458845,
+        1511799789,
         85682091
     ],
     "wof:breaches":[],
@@ -48,13 +49,14 @@
         {
             "continent_id":102191575,
             "country_id":85633041,
+            "county_id":1511799789,
             "locality_id":890458845,
             "neighbourhood_id":420783915,
             "region_id":85682091
         }
     ],
     "wof:id":420783915,
-    "wof:lastmodified":1566657451,
+    "wof:lastmodified":1577998131,
     "wof:name":"West Hillhurst",
     "wof:parent_id":890458845,
     "wof:placetype":"neighbourhood",

--- a/data/420/783/917/420783917.geojson
+++ b/data/420/783/917/420783917.geojson
@@ -28,8 +28,9 @@
     ],
     "wof:belongsto":[
         102191575,
-        890458845,
         85633041,
+        890458845,
+        1511799789,
         85682091
     ],
     "wof:breaches":[],
@@ -44,13 +45,14 @@
         {
             "continent_id":102191575,
             "country_id":85633041,
+            "county_id":1511799789,
             "locality_id":890458845,
             "neighbourhood_id":420783917,
             "region_id":85682091
         }
     ],
     "wof:id":420783917,
-    "wof:lastmodified":1566657473,
+    "wof:lastmodified":1577998133,
     "wof:name":"Spruce Cliff",
     "wof:parent_id":890458845,
     "wof:placetype":"neighbourhood",

--- a/data/420/783/919/420783919.geojson
+++ b/data/420/783/919/420783919.geojson
@@ -32,8 +32,9 @@
     "wd:wordcount":375,
     "wof:belongsto":[
         102191575,
-        890458845,
         85633041,
+        890458845,
+        1511799789,
         85682091
     ],
     "wof:breaches":[],
@@ -48,13 +49,14 @@
         {
             "continent_id":102191575,
             "country_id":85633041,
+            "county_id":1511799789,
             "locality_id":890458845,
             "neighbourhood_id":420783919,
             "region_id":85682091
         }
     ],
     "wof:id":420783919,
-    "wof:lastmodified":1566657472,
+    "wof:lastmodified":1577998135,
     "wof:name":"Springbank Hill",
     "wof:parent_id":890458845,
     "wof:placetype":"neighbourhood",

--- a/data/420/783/923/420783923.geojson
+++ b/data/420/783/923/420783923.geojson
@@ -25,8 +25,9 @@
     "mz:tier_locality":0,
     "wof:belongsto":[
         102191575,
-        890458845,
         85633041,
+        890458845,
+        1511799789,
         85682091
     ],
     "wof:breaches":[],
@@ -40,13 +41,14 @@
         {
             "continent_id":102191575,
             "country_id":85633041,
+            "county_id":1511799789,
             "locality_id":890458845,
             "neighbourhood_id":420783923,
             "region_id":85682091
         }
     ],
     "wof:id":420783923,
-    "wof:lastmodified":1566657452,
+    "wof:lastmodified":1577998133,
     "wof:name":"Varsity Estates",
     "wof:parent_id":890458845,
     "wof:placetype":"neighbourhood",

--- a/data/420/783/925/420783925.geojson
+++ b/data/420/783/925/420783925.geojson
@@ -35,8 +35,9 @@
     "wd:wordcount":706,
     "wof:belongsto":[
         102191575,
-        890458845,
         85633041,
+        890458845,
+        1511799789,
         85682091
     ],
     "wof:breaches":[],
@@ -51,13 +52,14 @@
         {
             "continent_id":102191575,
             "country_id":85633041,
+            "county_id":1511799789,
             "locality_id":890458845,
             "neighbourhood_id":420783925,
             "region_id":85682091
         }
     ],
     "wof:id":420783925,
-    "wof:lastmodified":1566657454,
+    "wof:lastmodified":1577998134,
     "wof:name":"Varsity Village",
     "wof:parent_id":890458845,
     "wof:placetype":"neighbourhood",

--- a/data/420/783/927/420783927.geojson
+++ b/data/420/783/927/420783927.geojson
@@ -28,8 +28,9 @@
     ],
     "wof:belongsto":[
         102191575,
-        890458845,
         85633041,
+        890458845,
+        1511799789,
         85682091
     ],
     "wof:breaches":[],
@@ -44,13 +45,14 @@
         {
             "continent_id":102191575,
             "country_id":85633041,
+            "county_id":1511799789,
             "locality_id":890458845,
             "neighbourhood_id":420783927,
             "region_id":85682091
         }
     ],
     "wof:id":420783927,
-    "wof:lastmodified":1566657470,
+    "wof:lastmodified":1577998135,
     "wof:name":"Royal Vista",
     "wof:parent_id":890458845,
     "wof:placetype":"neighbourhood",

--- a/data/420/783/929/420783929.geojson
+++ b/data/420/783/929/420783929.geojson
@@ -38,7 +38,8 @@
         102191575,
         1108963895,
         85633041,
-        890458845
+        890458845,
+        1511799789
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -52,6 +53,7 @@
         {
             "continent_id":102191575,
             "country_id":85633041,
+            "county_id":1511799789,
             "locality_id":890458845,
             "macrohood_id":1108963895,
             "neighbourhood_id":420783929,
@@ -59,7 +61,7 @@
         }
     ],
     "wof:id":420783929,
-    "wof:lastmodified":1566657470,
+    "wof:lastmodified":1577998137,
     "wof:name":"Sage Hill",
     "wof:parent_id":1108963895,
     "wof:placetype":"neighbourhood",

--- a/data/420/783/931/420783931.geojson
+++ b/data/420/783/931/420783931.geojson
@@ -34,7 +34,8 @@
         102191575,
         1108963895,
         85633041,
-        890458845
+        890458845,
+        1511799789
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -48,6 +49,7 @@
         {
             "continent_id":102191575,
             "country_id":85633041,
+            "county_id":1511799789,
             "locality_id":890458845,
             "macrohood_id":1108963895,
             "neighbourhood_id":420783931,
@@ -55,7 +57,7 @@
         }
     ],
     "wof:id":420783931,
-    "wof:lastmodified":1566657431,
+    "wof:lastmodified":1577998136,
     "wof:name":"Nolan Hill",
     "wof:parent_id":1108963895,
     "wof:placetype":"neighbourhood",

--- a/data/420/783/933/420783933.geojson
+++ b/data/420/783/933/420783933.geojson
@@ -31,7 +31,8 @@
         102191575,
         1108963895,
         85633041,
-        890458845
+        890458845,
+        1511799789
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -45,6 +46,7 @@
         {
             "continent_id":102191575,
             "country_id":85633041,
+            "county_id":1511799789,
             "locality_id":890458845,
             "macrohood_id":1108963895,
             "neighbourhood_id":420783933,
@@ -52,7 +54,7 @@
         }
     ],
     "wof:id":420783933,
-    "wof:lastmodified":1566657459,
+    "wof:lastmodified":1577998134,
     "wof:name":"Sherwood",
     "wof:parent_id":1108963895,
     "wof:placetype":"neighbourhood",

--- a/data/420/783/935/420783935.geojson
+++ b/data/420/783/935/420783935.geojson
@@ -32,7 +32,8 @@
         102191575,
         1108963895,
         85633041,
-        890458845
+        890458845,
+        1511799789
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -46,6 +47,7 @@
         {
             "continent_id":102191575,
             "country_id":85633041,
+            "county_id":1511799789,
             "locality_id":890458845,
             "macrohood_id":1108963895,
             "neighbourhood_id":420783935,
@@ -53,7 +55,7 @@
         }
     ],
     "wof:id":420783935,
-    "wof:lastmodified":1566657456,
+    "wof:lastmodified":1577998133,
     "wof:name":"Kincora",
     "wof:parent_id":1108963895,
     "wof:placetype":"neighbourhood",

--- a/data/420/783/937/420783937.geojson
+++ b/data/420/783/937/420783937.geojson
@@ -32,8 +32,9 @@
     "wd:wordcount":362,
     "wof:belongsto":[
         102191575,
-        890458845,
         85633041,
+        890458845,
+        1511799789,
         85682091
     ],
     "wof:breaches":[],
@@ -48,13 +49,14 @@
         {
             "continent_id":102191575,
             "country_id":85633041,
+            "county_id":1511799789,
             "locality_id":890458845,
             "neighbourhood_id":420783937,
             "region_id":85682091
         }
     ],
     "wof:id":420783937,
-    "wof:lastmodified":1566657434,
+    "wof:lastmodified":1577998132,
     "wof:name":"Country Hills Village",
     "wof:parent_id":890458845,
     "wof:placetype":"neighbourhood",

--- a/data/420/783/941/420783941.geojson
+++ b/data/420/783/941/420783941.geojson
@@ -25,8 +25,9 @@
     "mz:tier_locality":0,
     "wof:belongsto":[
         102191575,
-        890458845,
         85633041,
+        890458845,
+        1511799789,
         85682091
     ],
     "wof:breaches":[],
@@ -38,13 +39,14 @@
         {
             "continent_id":102191575,
             "country_id":85633041,
+            "county_id":1511799789,
             "locality_id":890458845,
             "neighbourhood_id":420783941,
             "region_id":85682091
         }
     ],
     "wof:id":420783941,
-    "wof:lastmodified":1566657450,
+    "wof:lastmodified":1577998135,
     "wof:name":"Skyview Ranch",
     "wof:parent_id":890458845,
     "wof:placetype":"neighbourhood",

--- a/data/420/783/943/420783943.geojson
+++ b/data/420/783/943/420783943.geojson
@@ -34,8 +34,9 @@
     ],
     "wof:belongsto":[
         102191575,
-        890458845,
         85633041,
+        890458845,
+        1511799789,
         85682091
     ],
     "wof:breaches":[],
@@ -50,13 +51,14 @@
         {
             "continent_id":102191575,
             "country_id":85633041,
+            "county_id":1511799789,
             "locality_id":890458845,
             "neighbourhood_id":420783943,
             "region_id":85682091
         }
     ],
     "wof:id":420783943,
-    "wof:lastmodified":1566657474,
+    "wof:lastmodified":1577998134,
     "wof:name":"Saddle Ridge",
     "wof:parent_id":890458845,
     "wof:placetype":"neighbourhood",

--- a/data/420/783/945/420783945.geojson
+++ b/data/420/783/945/420783945.geojson
@@ -38,8 +38,9 @@
     "wd:wordcount":24,
     "wof:belongsto":[
         102191575,
-        890458845,
         85633041,
+        890458845,
+        1511799789,
         85682091
     ],
     "wof:breaches":[],
@@ -54,13 +55,14 @@
         {
             "continent_id":102191575,
             "country_id":85633041,
+            "county_id":1511799789,
             "locality_id":890458845,
             "neighbourhood_id":420783945,
             "region_id":85682091
         }
     ],
     "wof:id":420783945,
-    "wof:lastmodified":1566657472,
+    "wof:lastmodified":1577998133,
     "wof:name":"Monterey Park",
     "wof:parent_id":890458845,
     "wof:placetype":"neighbourhood",

--- a/data/420/783/947/420783947.geojson
+++ b/data/420/783/947/420783947.geojson
@@ -32,8 +32,9 @@
     "wd:wordcount":294,
     "wof:belongsto":[
         102191575,
-        890458845,
         85633041,
+        890458845,
+        1511799789,
         85682091
     ],
     "wof:breaches":[],
@@ -48,13 +49,14 @@
         {
             "continent_id":102191575,
             "country_id":85633041,
+            "county_id":1511799789,
             "locality_id":890458845,
             "neighbourhood_id":420783947,
             "region_id":85682091
         }
     ],
     "wof:id":420783947,
-    "wof:lastmodified":1566657453,
+    "wof:lastmodified":1577998138,
     "wof:name":"Marlborough Park",
     "wof:parent_id":890458845,
     "wof:placetype":"neighbourhood",

--- a/data/420/783/949/420783949.geojson
+++ b/data/420/783/949/420783949.geojson
@@ -98,8 +98,9 @@
     "wd:wordcount":526,
     "wof:belongsto":[
         102191575,
-        890458845,
         85633041,
+        890458845,
+        1511799789,
         85682091
     ],
     "wof:breaches":[],
@@ -114,13 +115,14 @@
         {
             "continent_id":102191575,
             "country_id":85633041,
+            "county_id":1511799789,
             "locality_id":890458845,
             "neighbourhood_id":420783949,
             "region_id":85682091
         }
     ],
     "wof:id":420783949,
-    "wof:lastmodified":1566657453,
+    "wof:lastmodified":1577998138,
     "wof:name":"Red Carpet",
     "wof:parent_id":890458845,
     "wof:placetype":"neighbourhood",

--- a/data/420/783/951/420783951.geojson
+++ b/data/420/783/951/420783951.geojson
@@ -56,8 +56,9 @@
     "wd:wordcount":126,
     "wof:belongsto":[
         102191575,
-        890458845,
         85633041,
+        890458845,
+        1511799789,
         85682091
     ],
     "wof:breaches":[],
@@ -72,13 +73,14 @@
         {
             "continent_id":102191575,
             "country_id":85633041,
+            "county_id":1511799789,
             "locality_id":890458845,
             "neighbourhood_id":420783951,
             "region_id":85682091
         }
     ],
     "wof:id":420783951,
-    "wof:lastmodified":1566657458,
+    "wof:lastmodified":1577998133,
     "wof:name":"Ramsay",
     "wof:parent_id":890458845,
     "wof:placetype":"neighbourhood",

--- a/data/420/783/953/420783953.geojson
+++ b/data/420/783/953/420783953.geojson
@@ -28,8 +28,9 @@
     ],
     "wof:belongsto":[
         102191575,
-        890458845,
         85633041,
+        890458845,
+        1511799789,
         85682091
     ],
     "wof:breaches":[],
@@ -44,13 +45,14 @@
         {
             "continent_id":102191575,
             "country_id":85633041,
+            "county_id":1511799789,
             "locality_id":890458845,
             "neighbourhood_id":420783953,
             "region_id":85682091
         }
     ],
     "wof:id":420783953,
-    "wof:lastmodified":1566657432,
+    "wof:lastmodified":1577998137,
     "wof:name":"Southview",
     "wof:parent_id":890458845,
     "wof:placetype":"neighbourhood",

--- a/data/420/783/955/420783955.geojson
+++ b/data/420/783/955/420783955.geojson
@@ -38,8 +38,9 @@
     "wd:wordcount":614,
     "wof:belongsto":[
         102191575,
-        890458845,
         85633041,
+        890458845,
+        1511799789,
         85682091
     ],
     "wof:breaches":[],
@@ -53,13 +54,14 @@
         {
             "continent_id":102191575,
             "country_id":85633041,
+            "county_id":1511799789,
             "locality_id":890458845,
             "neighbourhood_id":420783955,
             "region_id":85682091
         }
     ],
     "wof:id":420783955,
-    "wof:lastmodified":1566657436,
+    "wof:lastmodified":1577998138,
     "wof:name":"Golden Triangle",
     "wof:parent_id":890458845,
     "wof:placetype":"neighbourhood",

--- a/data/420/783/959/420783959.geojson
+++ b/data/420/783/959/420783959.geojson
@@ -29,8 +29,9 @@
     "wd:wordcount":45,
     "wof:belongsto":[
         102191575,
-        890458845,
         85633041,
+        890458845,
+        1511799789,
         85682091
     ],
     "wof:breaches":[],
@@ -42,13 +43,14 @@
         {
             "continent_id":102191575,
             "country_id":85633041,
+            "county_id":1511799789,
             "locality_id":890458845,
             "neighbourhood_id":420783959,
             "region_id":85682091
         }
     ],
     "wof:id":420783959,
-    "wof:lastmodified":1566657455,
+    "wof:lastmodified":1577998131,
     "wof:name":"Eastfield",
     "wof:parent_id":890458845,
     "wof:placetype":"neighbourhood",

--- a/data/420/783/961/420783961.geojson
+++ b/data/420/783/961/420783961.geojson
@@ -83,8 +83,9 @@
     "wd:wordcount":274,
     "wof:belongsto":[
         102191575,
-        890458845,
         85633041,
+        890458845,
+        1511799789,
         85682091
     ],
     "wof:breaches":[],
@@ -98,13 +99,14 @@
         {
             "continent_id":102191575,
             "country_id":85633041,
+            "county_id":1511799789,
             "locality_id":890458845,
             "neighbourhood_id":420783961,
             "region_id":85682091
         }
     ],
     "wof:id":420783961,
-    "wof:lastmodified":1566657455,
+    "wof:lastmodified":1577998135,
     "wof:name":"Foothills",
     "wof:parent_id":890458845,
     "wof:placetype":"neighbourhood",

--- a/data/420/783/963/420783963.geojson
+++ b/data/420/783/963/420783963.geojson
@@ -32,8 +32,9 @@
     "wd:wordcount":33,
     "wof:belongsto":[
         102191575,
-        890458845,
         85633041,
+        890458845,
+        1511799789,
         85682091
     ],
     "wof:breaches":[],
@@ -45,13 +46,14 @@
         {
             "continent_id":102191575,
             "country_id":85633041,
+            "county_id":1511799789,
             "locality_id":890458845,
             "neighbourhood_id":420783963,
             "region_id":85682091
         }
     ],
     "wof:id":420783963,
-    "wof:lastmodified":1566657435,
+    "wof:lastmodified":1577998137,
     "wof:name":"Starfield",
     "wof:parent_id":890458845,
     "wof:placetype":"neighbourhood",

--- a/data/420/783/965/420783965.geojson
+++ b/data/420/783/965/420783965.geojson
@@ -203,8 +203,9 @@
     "wd:wordcount":3774,
     "wof:belongsto":[
         102191575,
-        890458845,
         85633041,
+        890458845,
+        1511799789,
         85682091
     ],
     "wof:breaches":[],
@@ -216,13 +217,14 @@
         {
             "continent_id":102191575,
             "country_id":85633041,
+            "county_id":1511799789,
             "locality_id":890458845,
             "neighbourhood_id":420783965,
             "region_id":85682091
         }
     ],
     "wof:id":420783965,
-    "wof:lastmodified":1566657433,
+    "wof:lastmodified":1577998134,
     "wof:name":"Great Plains",
     "wof:parent_id":890458845,
     "wof:placetype":"neighbourhood",

--- a/data/420/783/967/420783967.geojson
+++ b/data/420/783/967/420783967.geojson
@@ -25,8 +25,9 @@
     "mz:tier_locality":0,
     "wof:belongsto":[
         102191575,
-        890458845,
         85633041,
+        890458845,
+        1511799789,
         85682091
     ],
     "wof:breaches":[],
@@ -40,13 +41,14 @@
         {
             "continent_id":102191575,
             "country_id":85633041,
+            "county_id":1511799789,
             "locality_id":890458845,
             "neighbourhood_id":420783967,
             "region_id":85682091
         }
     ],
     "wof:id":420783967,
-    "wof:lastmodified":1566657457,
+    "wof:lastmodified":1577998132,
     "wof:name":"South Foothills",
     "wof:parent_id":890458845,
     "wof:placetype":"neighbourhood",

--- a/data/420/783/969/420783969.geojson
+++ b/data/420/783/969/420783969.geojson
@@ -31,8 +31,9 @@
     ],
     "wof:belongsto":[
         102191575,
-        890458845,
         85633041,
+        890458845,
+        1511799789,
         85682091
     ],
     "wof:breaches":[],
@@ -46,13 +47,14 @@
         {
             "continent_id":102191575,
             "country_id":85633041,
+            "county_id":1511799789,
             "locality_id":890458845,
             "neighbourhood_id":420783969,
             "region_id":85682091
         }
     ],
     "wof:id":420783969,
-    "wof:lastmodified":1566657458,
+    "wof:lastmodified":1577998136,
     "wof:name":"Highfield",
     "wof:parent_id":890458845,
     "wof:placetype":"neighbourhood",

--- a/data/420/783/971/420783971.geojson
+++ b/data/420/783/971/420783971.geojson
@@ -25,8 +25,9 @@
     "mz:tier_locality":0,
     "wof:belongsto":[
         102191575,
-        890458845,
         85633041,
+        890458845,
+        1511799789,
         85682091
     ],
     "wof:breaches":[],
@@ -40,13 +41,14 @@
         {
             "continent_id":102191575,
             "country_id":85633041,
+            "county_id":1511799789,
             "locality_id":890458845,
             "neighbourhood_id":420783971,
             "region_id":85682091
         }
     ],
     "wof:id":420783971,
-    "wof:lastmodified":1566657453,
+    "wof:lastmodified":1577998139,
     "wof:name":"Alyth-Bonnybrook",
     "wof:parent_id":890458845,
     "wof:placetype":"neighbourhood",

--- a/data/420/783/973/420783973.geojson
+++ b/data/420/783/973/420783973.geojson
@@ -25,8 +25,9 @@
     "mz:tier_locality":0,
     "wof:belongsto":[
         102191575,
-        890458845,
         85633041,
+        890458845,
+        1511799789,
         85682091
     ],
     "wof:breaches":[],
@@ -40,13 +41,14 @@
         {
             "continent_id":102191575,
             "country_id":85633041,
+            "county_id":1511799789,
             "locality_id":890458845,
             "neighbourhood_id":420783973,
             "region_id":85682091
         }
     ],
     "wof:id":420783973,
-    "wof:lastmodified":1566657471,
+    "wof:lastmodified":1577998138,
     "wof:name":"Burns Industrial",
     "wof:parent_id":890458845,
     "wof:placetype":"neighbourhood",

--- a/data/420/783/977/420783977.geojson
+++ b/data/420/783/977/420783977.geojson
@@ -25,8 +25,9 @@
     "mz:tier_locality":0,
     "wof:belongsto":[
         102191575,
-        890458845,
         85633041,
+        890458845,
+        1511799789,
         85682091
     ],
     "wof:breaches":[],
@@ -40,13 +41,14 @@
         {
             "continent_id":102191575,
             "country_id":85633041,
+            "county_id":1511799789,
             "locality_id":890458845,
             "neighbourhood_id":420783977,
             "region_id":85682091
         }
     ],
     "wof:id":420783977,
-    "wof:lastmodified":1566657449,
+    "wof:lastmodified":1577998132,
     "wof:name":"Manchester Industrial",
     "wof:parent_id":890458845,
     "wof:placetype":"neighbourhood",

--- a/data/420/783/979/420783979.geojson
+++ b/data/420/783/979/420783979.geojson
@@ -32,8 +32,9 @@
     "wd:wordcount":237,
     "wof:belongsto":[
         102191575,
-        890458845,
         85633041,
+        890458845,
+        1511799789,
         85682091
     ],
     "wof:breaches":[],
@@ -48,13 +49,14 @@
         {
             "continent_id":102191575,
             "country_id":85633041,
+            "county_id":1511799789,
             "locality_id":890458845,
             "neighbourhood_id":420783979,
             "region_id":85682091
         }
     ],
     "wof:id":420783979,
-    "wof:lastmodified":1566657450,
+    "wof:lastmodified":1577998137,
     "wof:name":"Shepard Industrial",
     "wof:parent_id":890458845,
     "wof:placetype":"neighbourhood",

--- a/data/420/783/981/420783981.geojson
+++ b/data/420/783/981/420783981.geojson
@@ -25,8 +25,9 @@
     "mz:tier_locality":0,
     "wof:belongsto":[
         102191575,
-        890458845,
         85633041,
+        890458845,
+        1511799789,
         85682091
     ],
     "wof:breaches":[],
@@ -40,13 +41,14 @@
         {
             "continent_id":102191575,
             "country_id":85633041,
+            "county_id":1511799789,
             "locality_id":890458845,
             "neighbourhood_id":420783981,
             "region_id":85682091
         }
     ],
     "wof:id":420783981,
-    "wof:lastmodified":1566657474,
+    "wof:lastmodified":1577998132,
     "wof:name":"East Shepard Industrial",
     "wof:parent_id":890458845,
     "wof:placetype":"neighbourhood",

--- a/data/420/783/983/420783983.geojson
+++ b/data/420/783/983/420783983.geojson
@@ -32,8 +32,9 @@
     "wd:wordcount":28,
     "wof:belongsto":[
         102191575,
-        890458845,
         85633041,
+        890458845,
+        1511799789,
         85682091
     ],
     "wof:breaches":[],
@@ -48,13 +49,14 @@
         {
             "continent_id":102191575,
             "country_id":85633041,
+            "county_id":1511799789,
             "locality_id":890458845,
             "neighbourhood_id":420783983,
             "region_id":85682091
         }
     ],
     "wof:id":420783983,
-    "wof:lastmodified":1566657450,
+    "wof:lastmodified":1577998136,
     "wof:name":"Strathcona Park",
     "wof:parent_id":890458845,
     "wof:placetype":"neighbourhood",

--- a/data/420/783/985/420783985.geojson
+++ b/data/420/783/985/420783985.geojson
@@ -32,8 +32,9 @@
     "wd:wordcount":298,
     "wof:belongsto":[
         102191575,
-        890458845,
         85633041,
+        890458845,
+        1511799789,
         85682091
     ],
     "wof:breaches":[],
@@ -48,13 +49,14 @@
         {
             "continent_id":102191575,
             "country_id":85633041,
+            "county_id":1511799789,
             "locality_id":890458845,
             "neighbourhood_id":420783985,
             "region_id":85682091
         }
     ],
     "wof:id":420783985,
-    "wof:lastmodified":1566657453,
+    "wof:lastmodified":1577998131,
     "wof:name":"Rosscarrock",
     "wof:parent_id":890458845,
     "wof:placetype":"neighbourhood",

--- a/data/420/783/987/420783987.geojson
+++ b/data/420/783/987/420783987.geojson
@@ -28,8 +28,9 @@
     ],
     "wof:belongsto":[
         102191575,
-        890458845,
         85633041,
+        890458845,
+        1511799789,
         85682091
     ],
     "wof:breaches":[],
@@ -44,13 +45,14 @@
         {
             "continent_id":102191575,
             "country_id":85633041,
+            "county_id":1511799789,
             "locality_id":890458845,
             "neighbourhood_id":420783987,
             "region_id":85682091
         }
     ],
     "wof:id":420783987,
-    "wof:lastmodified":1566657471,
+    "wof:lastmodified":1577998138,
     "wof:name":"Rutland Park",
     "wof:parent_id":890458845,
     "wof:placetype":"neighbourhood",

--- a/data/420/783/989/420783989.geojson
+++ b/data/420/783/989/420783989.geojson
@@ -29,8 +29,9 @@
     "wd:wordcount":3942,
     "wof:belongsto":[
         102191575,
-        890458845,
         85633041,
+        890458845,
+        1511799789,
         85682091
     ],
     "wof:breaches":[],
@@ -45,13 +46,14 @@
         {
             "continent_id":102191575,
             "country_id":85633041,
+            "county_id":1511799789,
             "locality_id":890458845,
             "neighbourhood_id":420783989,
             "region_id":85682091
         }
     ],
     "wof:id":420783989,
-    "wof:lastmodified":1566657472,
+    "wof:lastmodified":1577998138,
     "wof:name":"Lincoln Park",
     "wof:parent_id":890458845,
     "wof:placetype":"neighbourhood",

--- a/data/420/783/991/420783991.geojson
+++ b/data/420/783/991/420783991.geojson
@@ -32,8 +32,9 @@
     "wd:wordcount":417,
     "wof:belongsto":[
         102191575,
-        890458845,
         85633041,
+        890458845,
+        1511799789,
         85682091
     ],
     "wof:breaches":[],
@@ -48,13 +49,14 @@
         {
             "continent_id":102191575,
             "country_id":85633041,
+            "county_id":1511799789,
             "locality_id":890458845,
             "neighbourhood_id":420783991,
             "region_id":85682091
         }
     ],
     "wof:id":420783991,
-    "wof:lastmodified":1566657433,
+    "wof:lastmodified":1577998138,
     "wof:name":"North Glenmore Park",
     "wof:parent_id":890458845,
     "wof:placetype":"neighbourhood",

--- a/data/420/783/995/420783995.geojson
+++ b/data/420/783/995/420783995.geojson
@@ -25,8 +25,9 @@
     "mz:tier_locality":0,
     "wof:belongsto":[
         102191575,
-        890458845,
         85633041,
+        890458845,
+        1511799789,
         85682091
     ],
     "wof:breaches":[],
@@ -40,13 +41,14 @@
         {
             "continent_id":102191575,
             "country_id":85633041,
+            "county_id":1511799789,
             "locality_id":890458845,
             "neighbourhood_id":420783995,
             "region_id":85682091
         }
     ],
     "wof:id":420783995,
-    "wof:lastmodified":1566657455,
+    "wof:lastmodified":1577998137,
     "wof:name":"Garrison Woods",
     "wof:parent_id":890458845,
     "wof:placetype":"neighbourhood",

--- a/data/420/783/997/420783997.geojson
+++ b/data/420/783/997/420783997.geojson
@@ -37,8 +37,9 @@
     ],
     "wof:belongsto":[
         102191575,
-        890458845,
         85633041,
+        890458845,
+        1511799789,
         85682091
     ],
     "wof:breaches":[],
@@ -53,13 +54,14 @@
         {
             "continent_id":102191575,
             "country_id":85633041,
+            "county_id":1511799789,
             "locality_id":890458845,
             "neighbourhood_id":420783997,
             "region_id":85682091
         }
     ],
     "wof:id":420783997,
-    "wof:lastmodified":1566657435,
+    "wof:lastmodified":1577998134,
     "wof:name":"Altadore",
     "wof:parent_id":890458845,
     "wof:placetype":"neighbourhood",

--- a/data/420/783/999/420783999.geojson
+++ b/data/420/783/999/420783999.geojson
@@ -28,8 +28,9 @@
     ],
     "wof:belongsto":[
         102191575,
-        890458845,
         85633041,
+        890458845,
+        1511799789,
         85682091
     ],
     "wof:breaches":[],
@@ -44,13 +45,14 @@
         {
             "continent_id":102191575,
             "country_id":85633041,
+            "county_id":1511799789,
             "locality_id":890458845,
             "neighbourhood_id":420783999,
             "region_id":85682091
         }
     ],
     "wof:id":420783999,
-    "wof:lastmodified":1566657436,
+    "wof:lastmodified":1577998135,
     "wof:name":"Elbow Park",
     "wof:parent_id":890458845,
     "wof:placetype":"neighbourhood",

--- a/data/420/784/001/420784001.geojson
+++ b/data/420/784/001/420784001.geojson
@@ -92,8 +92,9 @@
     "wd:wordcount":1263,
     "wof:belongsto":[
         102191575,
-        890458845,
         85633041,
+        890458845,
+        1511799789,
         85682091
     ],
     "wof:breaches":[],
@@ -108,13 +109,14 @@
         {
             "continent_id":102191575,
             "country_id":85633041,
+            "county_id":1511799789,
             "locality_id":890458845,
             "neighbourhood_id":420784001,
             "region_id":85682091
         }
     ],
     "wof:id":420784001,
-    "wof:lastmodified":1566657486,
+    "wof:lastmodified":1577998125,
     "wof:name":"Windsor Park",
     "wof:parent_id":890458845,
     "wof:placetype":"neighbourhood",

--- a/data/420/784/003/420784003.geojson
+++ b/data/420/784/003/420784003.geojson
@@ -29,8 +29,9 @@
     "wd:wordcount":25,
     "wof:belongsto":[
         102191575,
-        890458845,
         85633041,
+        890458845,
+        1511799789,
         85682091
     ],
     "wof:breaches":[],
@@ -45,13 +46,14 @@
         {
             "continent_id":102191575,
             "country_id":85633041,
+            "county_id":1511799789,
             "locality_id":890458845,
             "neighbourhood_id":420784003,
             "region_id":85682091
         }
     ],
     "wof:id":420784003,
-    "wof:lastmodified":1566657500,
+    "wof:lastmodified":1577998126,
     "wof:name":"Meadowlark Park",
     "wof:parent_id":890458845,
     "wof:placetype":"neighbourhood",

--- a/data/420/784/005/420784005.geojson
+++ b/data/420/784/005/420784005.geojson
@@ -37,8 +37,9 @@
     ],
     "wof:belongsto":[
         102191575,
-        890458845,
         85633041,
+        890458845,
+        1511799789,
         85682091
     ],
     "wof:breaches":[],
@@ -53,13 +54,14 @@
         {
             "continent_id":102191575,
             "country_id":85633041,
+            "county_id":1511799789,
             "locality_id":890458845,
             "neighbourhood_id":420784005,
             "region_id":85682091
         }
     ],
     "wof:id":420784005,
-    "wof:lastmodified":1566657503,
+    "wof:lastmodified":1577998125,
     "wof:name":"Mayfair",
     "wof:parent_id":890458845,
     "wof:placetype":"neighbourhood",

--- a/data/420/784/007/420784007.geojson
+++ b/data/420/784/007/420784007.geojson
@@ -28,8 +28,9 @@
     ],
     "wof:belongsto":[
         102191575,
-        890458845,
         85633041,
+        890458845,
+        1511799789,
         85682091
     ],
     "wof:breaches":[],
@@ -44,13 +45,14 @@
         {
             "continent_id":102191575,
             "country_id":85633041,
+            "county_id":1511799789,
             "locality_id":890458845,
             "neighbourhood_id":420784007,
             "region_id":85682091
         }
     ],
     "wof:id":420784007,
-    "wof:lastmodified":1566657484,
+    "wof:lastmodified":1577998127,
     "wof:name":"Chinook Park",
     "wof:parent_id":890458845,
     "wof:placetype":"neighbourhood",

--- a/data/420/784/009/420784009.geojson
+++ b/data/420/784/009/420784009.geojson
@@ -29,8 +29,9 @@
     "wd:wordcount":66,
     "wof:belongsto":[
         102191575,
-        890458845,
         85633041,
+        890458845,
+        1511799789,
         85682091
     ],
     "wof:breaches":[],
@@ -45,13 +46,14 @@
         {
             "continent_id":102191575,
             "country_id":85633041,
+            "county_id":1511799789,
             "locality_id":890458845,
             "neighbourhood_id":420784009,
             "region_id":85682091
         }
     ],
     "wof:id":420784009,
-    "wof:lastmodified":1566657485,
+    "wof:lastmodified":1577998127,
     "wof:name":"Cedarbrae",
     "wof:parent_id":890458845,
     "wof:placetype":"neighbourhood",

--- a/data/420/784/013/420784013.geojson
+++ b/data/420/784/013/420784013.geojson
@@ -35,8 +35,9 @@
     "wd:wordcount":73,
     "wof:belongsto":[
         102191575,
-        890458845,
         85633041,
+        890458845,
+        1511799789,
         85682091
     ],
     "wof:breaches":[],
@@ -51,13 +52,14 @@
         {
             "continent_id":102191575,
             "country_id":85633041,
+            "county_id":1511799789,
             "locality_id":890458845,
             "neighbourhood_id":420784013,
             "region_id":85682091
         }
     ],
     "wof:id":420784013,
-    "wof:lastmodified":1566657481,
+    "wof:lastmodified":1577998128,
     "wof:name":"Willow Park",
     "wof:parent_id":890458845,
     "wof:placetype":"neighbourhood",

--- a/data/420/784/015/420784015.geojson
+++ b/data/420/784/015/420784015.geojson
@@ -29,8 +29,9 @@
     "wd:wordcount":72,
     "wof:belongsto":[
         102191575,
-        890458845,
         85633041,
+        890458845,
+        1511799789,
         85682091
     ],
     "wof:breaches":[],
@@ -45,13 +46,14 @@
         {
             "continent_id":102191575,
             "country_id":85633041,
+            "county_id":1511799789,
             "locality_id":890458845,
             "neighbourhood_id":420784015,
             "region_id":85682091
         }
     ],
     "wof:id":420784015,
-    "wof:lastmodified":1566657479,
+    "wof:lastmodified":1577998127,
     "wof:name":"Maple Ridge",
     "wof:parent_id":890458845,
     "wof:placetype":"neighbourhood",

--- a/data/420/784/017/420784017.geojson
+++ b/data/420/784/017/420784017.geojson
@@ -28,8 +28,9 @@
     ],
     "wof:belongsto":[
         102191575,
-        890458845,
         85633041,
+        890458845,
+        1511799789,
         85682091
     ],
     "wof:breaches":[],
@@ -44,13 +45,14 @@
         {
             "continent_id":102191575,
             "country_id":85633041,
+            "county_id":1511799789,
             "locality_id":890458845,
             "neighbourhood_id":420784017,
             "region_id":85682091
         }
     ],
     "wof:id":420784017,
-    "wof:lastmodified":1566657499,
+    "wof:lastmodified":1577998125,
     "wof:name":"Millrise",
     "wof:parent_id":890458845,
     "wof:placetype":"neighbourhood",

--- a/data/420/784/019/420784019.geojson
+++ b/data/420/784/019/420784019.geojson
@@ -28,8 +28,9 @@
     ],
     "wof:belongsto":[
         102191575,
-        890458845,
         85633041,
+        890458845,
+        1511799789,
         85682091
     ],
     "wof:breaches":[],
@@ -44,13 +45,14 @@
         {
             "continent_id":102191575,
             "country_id":85633041,
+            "county_id":1511799789,
             "locality_id":890458845,
             "neighbourhood_id":420784019,
             "region_id":85682091
         }
     ],
     "wof:id":420784019,
-    "wof:lastmodified":1566657499,
+    "wof:lastmodified":1577998128,
     "wof:name":"Deer Ridge",
     "wof:parent_id":890458845,
     "wof:placetype":"neighbourhood",

--- a/data/420/784/021/420784021.geojson
+++ b/data/420/784/021/420784021.geojson
@@ -29,8 +29,9 @@
     "wd:wordcount":4511,
     "wof:belongsto":[
         102191575,
-        890458845,
         85633041,
+        890458845,
+        1511799789,
         85682091
     ],
     "wof:breaches":[],
@@ -44,13 +45,14 @@
         {
             "continent_id":102191575,
             "country_id":85633041,
+            "county_id":1511799789,
             "locality_id":890458845,
             "neighbourhood_id":420784021,
             "region_id":85682091
         }
     ],
     "wof:id":420784021,
-    "wof:lastmodified":1566657500,
+    "wof:lastmodified":1577998128,
     "wof:name":"Walden",
     "wof:parent_id":890458845,
     "wof:placetype":"neighbourhood",

--- a/data/420/784/023/420784023.geojson
+++ b/data/420/784/023/420784023.geojson
@@ -59,8 +59,9 @@
     "wd:wordcount":1011,
     "wof:belongsto":[
         102191575,
-        890458845,
         85633041,
+        890458845,
+        1511799789,
         85682091
     ],
     "wof:breaches":[],
@@ -74,13 +75,14 @@
         {
             "continent_id":102191575,
             "country_id":85633041,
+            "county_id":1511799789,
             "locality_id":890458845,
             "neighbourhood_id":420784023,
             "region_id":85682091
         }
     ],
     "wof:id":420784023,
-    "wof:lastmodified":1566657478,
+    "wof:lastmodified":1577998128,
     "wof:name":"Legacy",
     "wof:parent_id":890458845,
     "wof:placetype":"neighbourhood",

--- a/data/420/784/025/420784025.geojson
+++ b/data/420/784/025/420784025.geojson
@@ -28,8 +28,9 @@
     ],
     "wof:belongsto":[
         102191575,
-        890458845,
         85633041,
+        890458845,
+        1511799789,
         85682091
     ],
     "wof:breaches":[],
@@ -44,13 +45,14 @@
         {
             "continent_id":102191575,
             "country_id":85633041,
+            "county_id":1511799789,
             "locality_id":890458845,
             "neighbourhood_id":420784025,
             "region_id":85682091
         }
     ],
     "wof:id":420784025,
-    "wof:lastmodified":1566657482,
+    "wof:lastmodified":1577998127,
     "wof:name":"Cranston",
     "wof:parent_id":890458845,
     "wof:placetype":"neighbourhood",

--- a/data/420/784/027/420784027.geojson
+++ b/data/420/784/027/420784027.geojson
@@ -28,8 +28,9 @@
     ],
     "wof:belongsto":[
         102191575,
-        890458845,
         85633041,
+        890458845,
+        1511799789,
         85682091
     ],
     "wof:breaches":[],
@@ -44,13 +45,14 @@
         {
             "continent_id":102191575,
             "country_id":85633041,
+            "county_id":1511799789,
             "locality_id":890458845,
             "neighbourhood_id":420784027,
             "region_id":85682091
         }
     ],
     "wof:id":420784027,
-    "wof:lastmodified":1566657497,
+    "wof:lastmodified":1577998128,
     "wof:name":"Auburn Bay",
     "wof:parent_id":890458845,
     "wof:placetype":"neighbourhood",

--- a/data/420/784/031/420784031.geojson
+++ b/data/420/784/031/420784031.geojson
@@ -47,8 +47,9 @@
     "wd:wordcount":219,
     "wof:belongsto":[
         102191575,
-        890458845,
         85633041,
+        890458845,
+        1511799789,
         85682091
     ],
     "wof:breaches":[],
@@ -62,13 +63,14 @@
         {
             "continent_id":102191575,
             "country_id":85633041,
+            "county_id":1511799789,
             "locality_id":890458845,
             "neighbourhood_id":420784031,
             "region_id":85682091
         }
     ],
     "wof:id":420784031,
-    "wof:lastmodified":1566657485,
+    "wof:lastmodified":1577998127,
     "wof:name":"Seton",
     "wof:parent_id":890458845,
     "wof:placetype":"neighbourhood",

--- a/data/420/784/033/420784033.geojson
+++ b/data/420/784/033/420784033.geojson
@@ -161,8 +161,9 @@
     "wd:wordcount":3235,
     "wof:belongsto":[
         102191575,
-        890458845,
         85633041,
+        890458845,
+        1511799789,
         85682091
     ],
     "wof:breaches":[],
@@ -176,13 +177,14 @@
         {
             "continent_id":102191575,
             "country_id":85633041,
+            "county_id":1511799789,
             "locality_id":890458845,
             "neighbourhood_id":420784033,
             "region_id":85682091
         }
     ],
     "wof:id":420784033,
-    "wof:lastmodified":1566657503,
+    "wof:lastmodified":1577998128,
     "wof:name":"Mahogany",
     "wof:parent_id":890458845,
     "wof:placetype":"neighbourhood",

--- a/data/420/784/035/420784035.geojson
+++ b/data/420/784/035/420784035.geojson
@@ -29,8 +29,9 @@
     "wd:wordcount":83,
     "wof:belongsto":[
         102191575,
-        890458845,
         85633041,
+        890458845,
+        1511799789,
         85682091
     ],
     "wof:breaches":[],
@@ -44,13 +45,14 @@
         {
             "continent_id":102191575,
             "country_id":85633041,
+            "county_id":1511799789,
             "locality_id":890458845,
             "neighbourhood_id":420784035,
             "region_id":85682091
         }
     ],
     "wof:id":420784035,
-    "wof:lastmodified":1566657501,
+    "wof:lastmodified":1577998129,
     "wof:name":"Copperfield",
     "wof:parent_id":890458845,
     "wof:placetype":"neighbourhood",

--- a/data/420/784/037/420784037.geojson
+++ b/data/420/784/037/420784037.geojson
@@ -32,8 +32,9 @@
     "wd:wordcount":300,
     "wof:belongsto":[
         102191575,
-        890458845,
         85633041,
+        890458845,
+        1511799789,
         85682091
     ],
     "wof:breaches":[],
@@ -47,13 +48,14 @@
         {
             "continent_id":102191575,
             "country_id":85633041,
+            "county_id":1511799789,
             "locality_id":890458845,
             "neighbourhood_id":420784037,
             "region_id":85682091
         }
     ],
     "wof:id":420784037,
-    "wof:lastmodified":1566657486,
+    "wof:lastmodified":1577998129,
     "wof:name":"Douglasdale-Douglasglen",
     "wof:parent_id":890458845,
     "wof:placetype":"neighbourhood",

--- a/data/420/784/039/420784039.geojson
+++ b/data/420/784/039/420784039.geojson
@@ -28,8 +28,9 @@
     ],
     "wof:belongsto":[
         102191575,
-        890458845,
         85633041,
+        890458845,
+        1511799789,
         85682091
     ],
     "wof:breaches":[],
@@ -44,13 +45,14 @@
         {
             "continent_id":102191575,
             "country_id":85633041,
+            "county_id":1511799789,
             "locality_id":890458845,
             "neighbourhood_id":420784039,
             "region_id":85682091
         }
     ],
     "wof:id":420784039,
-    "wof:lastmodified":1566657487,
+    "wof:lastmodified":1577998126,
     "wof:name":"Point McKay",
     "wof:parent_id":890458845,
     "wof:placetype":"neighbourhood",

--- a/data/420/784/041/420784041.geojson
+++ b/data/420/784/041/420784041.geojson
@@ -25,8 +25,9 @@
     "mz:tier_locality":0,
     "wof:belongsto":[
         102191575,
-        890458845,
         85633041,
+        890458845,
+        1511799789,
         85682091
     ],
     "wof:breaches":[],
@@ -40,13 +41,14 @@
         {
             "continent_id":102191575,
             "country_id":85633041,
+            "county_id":1511799789,
             "locality_id":890458845,
             "neighbourhood_id":420784041,
             "region_id":85682091
         }
     ],
     "wof:id":420784041,
-    "wof:lastmodified":1566657480,
+    "wof:lastmodified":1577998129,
     "wof:name":"Fairview Industrial",
     "wof:parent_id":890458845,
     "wof:placetype":"neighbourhood",

--- a/data/420/784/043/420784043.geojson
+++ b/data/420/784/043/420784043.geojson
@@ -25,8 +25,9 @@
     "mz:tier_locality":0,
     "wof:belongsto":[
         102191575,
-        890458845,
         85633041,
+        890458845,
+        1511799789,
         85682091
     ],
     "wof:breaches":[],
@@ -40,13 +41,14 @@
         {
             "continent_id":102191575,
             "country_id":85633041,
+            "county_id":1511799789,
             "locality_id":890458845,
             "neighbourhood_id":420784043,
             "region_id":85682091
         }
     ],
     "wof:id":420784043,
-    "wof:lastmodified":1566657499,
+    "wof:lastmodified":1577998129,
     "wof:name":"East Fairview Industrial",
     "wof:parent_id":890458845,
     "wof:placetype":"neighbourhood",

--- a/data/420/784/045/420784045.geojson
+++ b/data/420/784/045/420784045.geojson
@@ -25,8 +25,9 @@
     "mz:tier_locality":0,
     "wof:belongsto":[
         102191575,
-        890458845,
         85633041,
+        890458845,
+        1511799789,
         85682091
     ],
     "wof:breaches":[],
@@ -40,13 +41,14 @@
         {
             "continent_id":102191575,
             "country_id":85633041,
+            "county_id":1511799789,
             "locality_id":890458845,
             "neighbourhood_id":420784045,
             "region_id":85682091
         }
     ],
     "wof:id":420784045,
-    "wof:lastmodified":1566657496,
+    "wof:lastmodified":1577998129,
     "wof:name":"Glendeer Business Park",
     "wof:parent_id":890458845,
     "wof:placetype":"neighbourhood",

--- a/data/420/784/049/420784049.geojson
+++ b/data/420/784/049/420784049.geojson
@@ -25,8 +25,9 @@
     "mz:tier_locality":0,
     "wof:belongsto":[
         102191575,
-        890458845,
         85633041,
+        890458845,
+        1511799789,
         85682091
     ],
     "wof:breaches":[],
@@ -40,13 +41,14 @@
         {
             "continent_id":102191575,
             "country_id":85633041,
+            "county_id":1511799789,
             "locality_id":890458845,
             "neighbourhood_id":420784049,
             "region_id":85682091
         }
     ],
     "wof:id":420784049,
-    "wof:lastmodified":1566657483,
+    "wof:lastmodified":1577998129,
     "wof:name":"Bonavista Downs",
     "wof:parent_id":890458845,
     "wof:placetype":"neighbourhood",

--- a/data/420/784/051/420784051.geojson
+++ b/data/420/784/051/420784051.geojson
@@ -25,8 +25,9 @@
     "mz:tier_locality":0,
     "wof:belongsto":[
         102191575,
-        890458845,
         85633041,
+        890458845,
+        1511799789,
         85682091
     ],
     "wof:breaches":[],
@@ -40,13 +41,14 @@
         {
             "continent_id":102191575,
             "country_id":85633041,
+            "county_id":1511799789,
             "locality_id":890458845,
             "neighbourhood_id":420784051,
             "region_id":85682091
         }
     ],
     "wof:id":420784051,
-    "wof:lastmodified":1566657504,
+    "wof:lastmodified":1577998126,
     "wof:name":"Saddle Ridge Industrial",
     "wof:parent_id":890458845,
     "wof:placetype":"neighbourhood",

--- a/data/420/784/053/420784053.geojson
+++ b/data/420/784/053/420784053.geojson
@@ -53,8 +53,9 @@
     "wd:wordcount":346,
     "wof:belongsto":[
         102191575,
-        890458845,
         85633041,
+        890458845,
+        1511799789,
         85682091
     ],
     "wof:breaches":[],
@@ -66,13 +67,14 @@
         {
             "continent_id":102191575,
             "country_id":85633041,
+            "county_id":1511799789,
             "locality_id":890458845,
             "neighbourhood_id":420784053,
             "region_id":85682091
         }
     ],
     "wof:id":420784053,
-    "wof:lastmodified":1566657484,
+    "wof:lastmodified":1577998126,
     "wof:name":"Redstone",
     "wof:parent_id":890458845,
     "wof:placetype":"neighbourhood",

--- a/data/420/784/055/420784055.geojson
+++ b/data/420/784/055/420784055.geojson
@@ -28,8 +28,9 @@
     ],
     "wof:belongsto":[
         102191575,
-        890458845,
         85633041,
+        890458845,
+        1511799789,
         85682091
     ],
     "wof:breaches":[],
@@ -44,13 +45,14 @@
         {
             "continent_id":102191575,
             "country_id":85633041,
+            "county_id":1511799789,
             "locality_id":890458845,
             "neighbourhood_id":420784055,
             "region_id":85682091
         }
     ],
     "wof:id":420784055,
-    "wof:lastmodified":1566657485,
+    "wof:lastmodified":1577998130,
     "wof:name":"Highland Park",
     "wof:parent_id":890458845,
     "wof:placetype":"neighbourhood",

--- a/data/420/784/057/420784057.geojson
+++ b/data/420/784/057/420784057.geojson
@@ -25,8 +25,9 @@
     "mz:tier_locality":0,
     "wof:belongsto":[
         102191575,
-        890458845,
         85633041,
+        890458845,
+        1511799789,
         85682091
     ],
     "wof:breaches":[],
@@ -40,13 +41,14 @@
         {
             "continent_id":102191575,
             "country_id":85633041,
+            "county_id":1511799789,
             "locality_id":890458845,
             "neighbourhood_id":420784057,
             "region_id":85682091
         }
     ],
     "wof:id":420784057,
-    "wof:lastmodified":1566657502,
+    "wof:lastmodified":1577998126,
     "wof:name":"Aurora Business Park",
     "wof:parent_id":890458845,
     "wof:placetype":"neighbourhood",

--- a/data/420/784/059/420784059.geojson
+++ b/data/420/784/059/420784059.geojson
@@ -29,7 +29,8 @@
         102191575,
         1108963897,
         85633041,
-        890458845
+        890458845,
+        1511799789
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -42,6 +43,7 @@
         {
             "continent_id":102191575,
             "country_id":85633041,
+            "county_id":1511799789,
             "locality_id":890458845,
             "macrohood_id":1108963897,
             "neighbourhood_id":420784059,
@@ -49,7 +51,7 @@
         }
     ],
     "wof:id":420784059,
-    "wof:lastmodified":1566657502,
+    "wof:lastmodified":1577998130,
     "wof:name":"Centre City",
     "wof:parent_id":1108963897,
     "wof:placetype":"neighbourhood",

--- a/data/420/784/061/420784061.geojson
+++ b/data/420/784/061/420784061.geojson
@@ -124,8 +124,9 @@
     ],
     "wof:belongsto":[
         102191575,
-        890458845,
         85633041,
+        890458845,
+        1511799789,
         85682091
     ],
     "wof:breaches":[],
@@ -137,13 +138,14 @@
         {
             "continent_id":102191575,
             "country_id":85633041,
+            "county_id":1511799789,
             "locality_id":890458845,
             "neighbourhood_id":420784061,
             "region_id":85682091
         }
     ],
     "wof:id":420784061,
-    "wof:lastmodified":1566657501,
+    "wof:lastmodified":1577998130,
     "wof:name":"Northwest",
     "wof:parent_id":890458845,
     "wof:placetype":"neighbourhood",

--- a/data/420/784/063/420784063.geojson
+++ b/data/420/784/063/420784063.geojson
@@ -148,8 +148,9 @@
     ],
     "wof:belongsto":[
         102191575,
-        890458845,
         85633041,
+        890458845,
+        1511799789,
         85682091
     ],
     "wof:breaches":[],
@@ -163,13 +164,14 @@
         {
             "continent_id":102191575,
             "country_id":85633041,
+            "county_id":1511799789,
             "locality_id":890458845,
             "neighbourhood_id":420784063,
             "region_id":85682091
         }
     ],
     "wof:id":420784063,
-    "wof:lastmodified":1566657486,
+    "wof:lastmodified":1577998130,
     "wof:name":"Northeast",
     "wof:parent_id":890458845,
     "wof:placetype":"neighbourhood",

--- a/data/420/784/067/420784067.geojson
+++ b/data/420/784/067/420784067.geojson
@@ -145,8 +145,9 @@
     ],
     "wof:belongsto":[
         102191575,
-        890458845,
         85633041,
+        890458845,
+        1511799789,
         85682091
     ],
     "wof:breaches":[],
@@ -160,13 +161,14 @@
         {
             "continent_id":102191575,
             "country_id":85633041,
+            "county_id":1511799789,
             "locality_id":890458845,
             "neighbourhood_id":420784067,
             "region_id":85682091
         }
     ],
     "wof:id":420784067,
-    "wof:lastmodified":1566657504,
+    "wof:lastmodified":1577998126,
     "wof:name":"Southeast",
     "wof:parent_id":890458845,
     "wof:placetype":"neighbourhood",

--- a/data/420/784/069/420784069.geojson
+++ b/data/420/784/069/420784069.geojson
@@ -133,8 +133,9 @@
     ],
     "wof:belongsto":[
         102191575,
-        890458845,
         85633041,
+        890458845,
+        1511799789,
         85682091
     ],
     "wof:breaches":[],
@@ -146,13 +147,14 @@
         {
             "continent_id":102191575,
             "country_id":85633041,
+            "county_id":1511799789,
             "locality_id":890458845,
             "neighbourhood_id":420784069,
             "region_id":85682091
         }
     ],
     "wof:id":420784069,
-    "wof:lastmodified":1566657504,
+    "wof:lastmodified":1577998130,
     "wof:name":"Southwest",
     "wof:parent_id":890458845,
     "wof:placetype":"neighbourhood",

--- a/data/420/784/071/420784071.geojson
+++ b/data/420/784/071/420784071.geojson
@@ -56,8 +56,9 @@
     "wd:wordcount":521,
     "wof:belongsto":[
         102191575,
-        890458845,
         85633041,
+        890458845,
+        1511799789,
         85682091
     ],
     "wof:breaches":[],
@@ -72,13 +73,14 @@
         {
             "continent_id":102191575,
             "country_id":85633041,
+            "county_id":1511799789,
             "locality_id":890458845,
             "neighbourhood_id":420784071,
             "region_id":85682091
         }
     ],
     "wof:id":420784071,
-    "wof:lastmodified":1566657482,
+    "wof:lastmodified":1577998130,
     "wof:name":"Inner City",
     "wof:parent_id":890458845,
     "wof:placetype":"neighbourhood",

--- a/data/420/784/073/420784073.geojson
+++ b/data/420/784/073/420784073.geojson
@@ -28,8 +28,9 @@
     ],
     "wof:belongsto":[
         102191575,
-        890458845,
         85633041,
+        890458845,
+        1511799789,
         85682091
     ],
     "wof:breaches":[],
@@ -44,13 +45,14 @@
         {
             "continent_id":102191575,
             "country_id":85633041,
+            "county_id":1511799789,
             "locality_id":890458845,
             "neighbourhood_id":420784073,
             "region_id":85682091
         }
     ],
     "wof:id":420784073,
-    "wof:lastmodified":1566657497,
+    "wof:lastmodified":1577998130,
     "wof:name":"Marda Loop",
     "wof:parent_id":890458845,
     "wof:placetype":"neighbourhood",

--- a/data/420/784/075/420784075.geojson
+++ b/data/420/784/075/420784075.geojson
@@ -28,8 +28,9 @@
     ],
     "wof:belongsto":[
         102191575,
-        890458845,
         85633041,
+        890458845,
+        1511799789,
         85682091
     ],
     "wof:breaches":[],
@@ -44,13 +45,14 @@
         {
             "continent_id":102191575,
             "country_id":85633041,
+            "county_id":1511799789,
             "locality_id":890458845,
             "neighbourhood_id":420784075,
             "region_id":85682091
         }
     ],
     "wof:id":420784075,
-    "wof:lastmodified":1566657498,
+    "wof:lastmodified":1577998127,
     "wof:name":"Kensington",
     "wof:parent_id":890458845,
     "wof:placetype":"neighbourhood",

--- a/data/420/784/077/420784077.geojson
+++ b/data/420/784/077/420784077.geojson
@@ -32,8 +32,9 @@
     "wd:wordcount":344,
     "wof:belongsto":[
         102191575,
-        890458845,
         85633041,
+        890458845,
+        1511799789,
         85682091
     ],
     "wof:breaches":[],
@@ -48,13 +49,14 @@
         {
             "continent_id":102191575,
             "country_id":85633041,
+            "county_id":1511799789,
             "locality_id":890458845,
             "neighbourhood_id":420784077,
             "region_id":85682091
         }
     ],
     "wof:id":420784077,
-    "wof:lastmodified":1566657480,
+    "wof:lastmodified":1577998131,
     "wof:name":"Hounsfield Heights/Briar Hill",
     "wof:parent_id":890458845,
     "wof:placetype":"neighbourhood",

--- a/data/857/648/73/85764873.geojson
+++ b/data/857/648/73/85764873.geojson
@@ -71,6 +71,10 @@
         "qs_pg:id":462573
     },
     "wof:country":"",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"5b7a369feb3999a627e091228cad45ea",
     "wof:hierarchy":[
         {
@@ -96,7 +100,7 @@
     "wof:lang":[
         "fre"
     ],
-    "wof:lastmodified":1566657207,
+    "wof:lastmodified":1582332147,
     "wof:name":"Banlieue-Sud",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/857/650/69/85765069.geojson
+++ b/data/857/650/69/85765069.geojson
@@ -75,15 +75,19 @@
     "wof:geomhash":"5175e8e69ca3b3b44fd6f23d549dedf3",
     "wof:hierarchy":[
         {
+            "continent_id":-1,
+            "country_id":-1,
             "county_id":102060157,
-            "neighbourhood_id":85765069
+            "locality_id":-1,
+            "neighbourhood_id":85765069,
+            "region_id":-1
         }
     ],
     "wof:id":85765069,
     "wof:lang":[
         "por"
     ],
-    "wof:lastmodified":1566657206,
+    "wof:lastmodified":1577829536,
     "wof:name":"Assun\u00e7\u00e3o Vila",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/857/656/87/85765687.geojson
+++ b/data/857/656/87/85765687.geojson
@@ -212,6 +212,10 @@
         "qs_pg:id":889902
     },
     "wof:country":"",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"8bf98e423f58846a55d69594a3da5254",
     "wof:hierarchy":[
         {
@@ -227,7 +231,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1566657206,
+    "wof:lastmodified":1582332147,
     "wof:name":"Santa Cruz",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/857/656/93/85765693.geojson
+++ b/data/857/656/93/85765693.geojson
@@ -70,6 +70,10 @@
         "qs_pg:id":1087509
     },
     "wof:country":"",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"110a227a54fd30ce22f4633c1c9a56cf",
     "wof:hierarchy":[
         {
@@ -85,7 +89,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1566657206,
+    "wof:lastmodified":1582332147,
     "wof:name":"Orrantia del Mar",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/857/669/25/85766925.geojson
+++ b/data/857/669/25/85766925.geojson
@@ -57,11 +57,12 @@
     ],
     "src:lbl_centroid":"yerbashapes",
     "wof:belongsto":[
-        85682015,
         102191577,
         85633009,
+        1511777409,
         101960525,
-        102059767
+        102059767,
+        85682015
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -69,6 +70,9 @@
         "qs_pg:id":508732
     },
     "wof:country":"",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"92febbe0dbb43a273060b8b745d44c58",
     "wof:hierarchy":[
         {
@@ -76,6 +80,7 @@
             "country_id":85633009,
             "county_id":102059767,
             "locality_id":101960525,
+            "macroregion_id":1511777409,
             "neighbourhood_id":85766925,
             "region_id":85682015
         }
@@ -84,7 +89,7 @@
     "wof:lang":[
         "por"
     ],
-    "wof:lastmodified":1566657205,
+    "wof:lastmodified":1582332147,
     "wof:name":"Cidade Baixa",
     "wof:parent_id":101960525,
     "wof:placetype":"neighbourhood",

--- a/data/857/727/47/85772747.geojson
+++ b/data/857/727/47/85772747.geojson
@@ -94,6 +94,9 @@
         "wd:id":"Q6427405"
     },
     "wof:country":"",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"041de4b48f3f73b5c12084e9d6636b41",
     "wof:hierarchy":[
         {
@@ -109,7 +112,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566657207,
+    "wof:lastmodified":1582332147,
     "wof:name":"Kollupitiya",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/857/936/63/85793663.geojson
+++ b/data/857/936/63/85793663.geojson
@@ -72,6 +72,9 @@
         "qs_pg:id":1323608
     },
     "wof:country":"",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"0e97d588bd78c38b66fece95d08c31d6",
     "wof:hierarchy":[
         {
@@ -87,7 +90,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1566657205,
+    "wof:lastmodified":1582332147,
     "wof:name":"Reparto N\u00e1utico",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/857/992/69/85799269.geojson
+++ b/data/857/992/69/85799269.geojson
@@ -88,6 +88,10 @@
         "qs_pg:id":1193850
     },
     "wof:country":"",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"92382b7b7c7d46d7e4d8c8c509f9ad69",
     "wof:hierarchy":[
         {
@@ -104,7 +108,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1566657206,
+    "wof:lastmodified":1582332147,
     "wof:name":"Concepci\u00f3n Barrio de La",
     "wof:parent_id":101748203,
     "wof:placetype":"neighbourhood",

--- a/data/858/022/63/85802263.geojson
+++ b/data/858/022/63/85802263.geojson
@@ -93,6 +93,10 @@
         "wd:id":"Q1070799"
     },
     "wof:country":"",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"52f282195bcef841c2586af54fcd5802",
     "wof:hierarchy":[
         {
@@ -108,7 +112,7 @@
     "wof:lang":[
         "ara"
     ],
-    "wof:lastmodified":1566657208,
+    "wof:lastmodified":1582332147,
     "wof:name":"A\u00efn Diab",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/858/022/69/85802269.geojson
+++ b/data/858/022/69/85802269.geojson
@@ -72,6 +72,10 @@
         "qs_pg:id":1118222
     },
     "wof:country":"",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"fbc00581b68da9e821ede0740ce95811",
     "wof:hierarchy":[
         {
@@ -87,7 +91,7 @@
     "wof:lang":[
         "ara"
     ],
-    "wof:lastmodified":1566657208,
+    "wof:lastmodified":1582332147,
     "wof:name":"Anfa-Sup\u00e9rieur",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/858/022/73/85802273.geojson
+++ b/data/858/022/73/85802273.geojson
@@ -69,6 +69,10 @@
         "qs_pg:id":900168
     },
     "wof:country":"",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"6e1e603ff11cd7ed43fa8f94c34d9dac",
     "wof:hierarchy":[
         {
@@ -84,7 +88,7 @@
     "wof:lang":[
         "ara"
     ],
-    "wof:lastmodified":1566657208,
+    "wof:lastmodified":1582332147,
     "wof:name":"As Swissi",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/858/022/97/85802297.geojson
+++ b/data/858/022/97/85802297.geojson
@@ -79,6 +79,10 @@
         "qs_pg:id":1118276
     },
     "wof:country":"",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"32a5bf08627d8250dff9a4005bda08f6",
     "wof:hierarchy":[
         {
@@ -94,7 +98,7 @@
     "wof:lang":[
         "ara"
     ],
-    "wof:lastmodified":1566657208,
+    "wof:lastmodified":1582332147,
     "wof:name":"Les Camps",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/858/023/07/85802307.geojson
+++ b/data/858/023/07/85802307.geojson
@@ -74,6 +74,10 @@
         "qs_pg:id":900175
     },
     "wof:country":"",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"3222bcb8f6453680f1bbf64ac48bf7cb",
     "wof:hierarchy":[
         {
@@ -89,7 +93,7 @@
     "wof:lang":[
         "ara"
     ],
-    "wof:lastmodified":1566657207,
+    "wof:lastmodified":1582332147,
     "wof:name":"Ouda\u00efa",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/003/71/85900371.geojson
+++ b/data/859/003/71/85900371.geojson
@@ -144,6 +144,9 @@
         "qs_pg:id":1193535
     },
     "wof:country":"",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"1317a60cd8bc88cdcdf6f1b2f8d8f1c7",
     "wof:hierarchy":[
         {
@@ -160,7 +163,7 @@
     "wof:lang":[
         "ita"
     ],
-    "wof:lastmodified":1566657204,
+    "wof:lastmodified":1582332146,
     "wof:name":"Giudecca",
     "wof:parent_id":101795213,
     "wof:placetype":"neighbourhood",

--- a/data/859/003/73/85900373.geojson
+++ b/data/859/003/73/85900373.geojson
@@ -144,6 +144,9 @@
         "qs_pg:id":1193532
     },
     "wof:country":"",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"669c3e9156dd5d97ec026250cb88dd12",
     "wof:hierarchy":[
         {
@@ -160,7 +163,7 @@
     "wof:lang":[
         "ita"
     ],
-    "wof:lastmodified":1566657203,
+    "wof:lastmodified":1582332146,
     "wof:name":"San Giorgio Maggiore",
     "wof:parent_id":101795213,
     "wof:placetype":"neighbourhood",

--- a/data/859/003/75/85900375.geojson
+++ b/data/859/003/75/85900375.geojson
@@ -127,6 +127,9 @@
         "wd:id":"Q544119"
     },
     "wof:country":"",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"dba5793843b5da73e4c4e4cbbd71e22a",
     "wof:hierarchy":[
         {
@@ -138,7 +141,7 @@
     "wof:lang":[
         "ita"
     ],
-    "wof:lastmodified":1566657203,
+    "wof:lastmodified":1582332146,
     "wof:name":"Sacca Fisola",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/030/53/85903053.geojson
+++ b/data/859/030/53/85903053.geojson
@@ -73,6 +73,10 @@
         "qs_pg:id":911299
     },
     "wof:country":"",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"b669344769a8886966846bb05e6cb532",
     "wof:hierarchy":[
         {
@@ -87,7 +91,7 @@
     "wof:lang":[
         "ara"
     ],
-    "wof:lastmodified":1566657197,
+    "wof:lastmodified":1582332145,
     "wof:name":"Ar Rumayl",
     "wof:parent_id":890442383,
     "wof:placetype":"neighbourhood",

--- a/data/859/030/55/85903055.geojson
+++ b/data/859/030/55/85903055.geojson
@@ -83,6 +83,10 @@
         "qs_pg:id":1087009
     },
     "wof:country":"",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"7d9520ef52b2b838b3f7a76c1f138adf",
     "wof:hierarchy":[
         {
@@ -97,7 +101,7 @@
     "wof:lang":[
         "ara"
     ],
-    "wof:lastmodified":1566657197,
+    "wof:lastmodified":1582332145,
     "wof:name":"\u0628\u0627\u0628 \u0627\u062f\u0631\u064a\u0633",
     "wof:parent_id":890442383,
     "wof:placetype":"neighbourhood",

--- a/data/859/050/13/85905013.geojson
+++ b/data/859/050/13/85905013.geojson
@@ -155,6 +155,9 @@
         "wd:id":"Q52423"
     },
     "wof:country":"",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"6534b7329505df8402645d3cd5a0cf30",
     "wof:hierarchy":[
         {
@@ -171,7 +174,7 @@
     "wof:lang":[
         "ita"
     ],
-    "wof:lastmodified":1566657204,
+    "wof:lastmodified":1582332147,
     "wof:name":"Cannaregio",
     "wof:parent_id":101752689,
     "wof:placetype":"neighbourhood",

--- a/data/859/064/77/85906477.geojson
+++ b/data/859/064/77/85906477.geojson
@@ -139,6 +139,9 @@
         "wd:id":"Q1767191"
     },
     "wof:country":"",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"c1ce62397edab8374eaea475548f73e8",
     "wof:hierarchy":[
         {
@@ -151,7 +154,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566657196,
+    "wof:lastmodified":1582332145,
     "wof:name":"Tahtakale",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/071/35/85907135.geojson
+++ b/data/859/071/35/85907135.geojson
@@ -67,6 +67,9 @@
         "qs_pg:id":1085674
     },
     "wof:country":"",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"bab51cf6c5f51a52a084e4a1a1165fa8",
     "wof:hierarchy":[
         {
@@ -82,7 +85,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566657194,
+    "wof:lastmodified":1582332145,
     "wof:name":"A-suwane",
     "wof:parent_id":421168681,
     "wof:placetype":"neighbourhood",

--- a/data/859/072/43/85907243.geojson
+++ b/data/859/072/43/85907243.geojson
@@ -69,6 +69,10 @@
         "qs_pg:id":1262812
     },
     "wof:country":"",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"bcac245c99e267ee91434f434588ab83",
     "wof:hierarchy":[
         {
@@ -83,7 +87,7 @@
     "wof:lang":[
         "ara"
     ],
-    "wof:lastmodified":1566657203,
+    "wof:lastmodified":1582332146,
     "wof:name":"Wattiya",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/075/51/85907551.geojson
+++ b/data/859/075/51/85907551.geojson
@@ -76,6 +76,10 @@
         "qs_pg:id":899071
     },
     "wof:country":"",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"7fccd33b6bddf37b39764eb8694fd8c2",
     "wof:hierarchy":[
         {
@@ -91,7 +95,7 @@
     "wof:lang":[
         "ara"
     ],
-    "wof:lastmodified":1566657202,
+    "wof:lastmodified":1582332146,
     "wof:name":"\u0627\u0644\u062d\u0645\u0631\u0627\u0621",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/075/53/85907553.geojson
+++ b/data/859/075/53/85907553.geojson
@@ -72,6 +72,10 @@
         "qs_pg:id":14562
     },
     "wof:country":"",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"1e8ab12a42537f30b350864c47922e90",
     "wof:hierarchy":[
         {
@@ -86,7 +90,7 @@
     "wof:lang":[
         "ara"
     ],
-    "wof:lastmodified":1566657203,
+    "wof:lastmodified":1582332146,
     "wof:name":"\u0627\u0644\u0628\u063a\u062f\u0627\u062f\u064a\u0629 \u0627\u0644\u063a\u0631\u0628\u064a\u0629",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/080/29/85908029.geojson
+++ b/data/859/080/29/85908029.geojson
@@ -87,6 +87,9 @@
         "wd:id":"Q1137504"
     },
     "wof:country":"",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"a9b011c77d24b3e223b5433b8ec6c8e2",
     "wof:hierarchy":[
         {
@@ -101,7 +104,7 @@
     "wof:lang":[
         "chi"
     ],
-    "wof:lastmodified":1566657202,
+    "wof:lastmodified":1582332146,
     "wof:name":"\u8001\u6f58",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/084/25/85908425.geojson
+++ b/data/859/084/25/85908425.geojson
@@ -77,6 +77,10 @@
         "qs_pg:id":511499
     },
     "wof:country":"",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"aa9405e99811d9a600a5cb9b1bf64952",
     "wof:hierarchy":[
         {
@@ -91,7 +95,7 @@
     "wof:lang":[
         "jpn"
     ],
-    "wof:lastmodified":1566657194,
+    "wof:lastmodified":1582332145,
     "wof:name":"\uff17\u4e01\u76ee",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/084/69/85908469.geojson
+++ b/data/859/084/69/85908469.geojson
@@ -80,6 +80,10 @@
         "qs_pg:id":979367
     },
     "wof:country":"",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"091cbf764ed8a125c7afdf08bbf32c22",
     "wof:hierarchy":[
         {
@@ -95,7 +99,7 @@
     "wof:lang":[
         "jpn"
     ],
-    "wof:lastmodified":1566657194,
+    "wof:lastmodified":1582332145,
     "wof:name":"\uff13\u4e01\u76ee",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/087/65/85908765.geojson
+++ b/data/859/087/65/85908765.geojson
@@ -79,6 +79,9 @@
         "qs_pg:id":1264873
     },
     "wof:country":"",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"9277f97782dace9fcf95264967eb9b23",
     "wof:hierarchy":[
         {
@@ -94,7 +97,7 @@
     "wof:lang":[
         "jpn"
     ],
-    "wof:lastmodified":1566657201,
+    "wof:lastmodified":1582332146,
     "wof:name":"\uff11\u4e01\u76ee",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/089/45/85908945.geojson
+++ b/data/859/089/45/85908945.geojson
@@ -81,6 +81,10 @@
         "qs_pg:id":1119732
     },
     "wof:country":"",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"59521d56b22b6e175cb91403f300ee74",
     "wof:hierarchy":[
         {
@@ -96,7 +100,7 @@
     "wof:lang":[
         "jpn"
     ],
-    "wof:lastmodified":1566657201,
+    "wof:lastmodified":1582332146,
     "wof:name":"\uff11\u4e01\u76ee",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/127/47/85912747.geojson
+++ b/data/859/127/47/85912747.geojson
@@ -76,6 +76,9 @@
         "qs_pg:id":1323066
     },
     "wof:country":"",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"9435320052fabde1846d5b46d8ff5f2c",
     "wof:hierarchy":[
         {
@@ -90,7 +93,7 @@
     "wof:lang":[
         "jpn"
     ],
-    "wof:lastmodified":1566657199,
+    "wof:lastmodified":1582332146,
     "wof:name":"\uff12\u4e01\u76ee",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/127/59/85912759.geojson
+++ b/data/859/127/59/85912759.geojson
@@ -82,6 +82,9 @@
         "qs_pg:id":1270358
     },
     "wof:country":"",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"c79341b7ea347f1251a1c047746e54da",
     "wof:hierarchy":[
         {
@@ -97,7 +100,7 @@
     "wof:lang":[
         "jpn"
     ],
-    "wof:lastmodified":1566657198,
+    "wof:lastmodified":1582332146,
     "wof:name":"\uff12\u4e01\u76ee",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/145/35/85914535.geojson
+++ b/data/859/145/35/85914535.geojson
@@ -79,6 +79,9 @@
         "qs_pg:id":249324
     },
     "wof:country":"",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"b86bded5526da944af50b02be1c59ea5",
     "wof:hierarchy":[
         {
@@ -94,7 +97,7 @@
     "wof:lang":[
         "jpn"
     ],
-    "wof:lastmodified":1566657197,
+    "wof:lastmodified":1582332146,
     "wof:name":"\uff12\u4e01\u76ee",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/147/25/85914725.geojson
+++ b/data/859/147/25/85914725.geojson
@@ -81,6 +81,10 @@
         "qs_pg:id":990754
     },
     "wof:country":"",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"134ff400fc22729ee21f417bb509b47f",
     "wof:hierarchy":[
         {
@@ -96,7 +100,7 @@
     "wof:lang":[
         "jpn"
     ],
-    "wof:lastmodified":1566657205,
+    "wof:lastmodified":1582332147,
     "wof:name":"\uff14\u4e01\u76ee",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/156/73/85915673.geojson
+++ b/data/859/156/73/85915673.geojson
@@ -80,6 +80,10 @@
         "qs_pg:id":373745
     },
     "wof:country":"",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"9bbcf49996d1d0940b2b93f8f9556208",
     "wof:hierarchy":[
         {
@@ -95,7 +99,7 @@
     "wof:lang":[
         "jpn"
     ],
-    "wof:lastmodified":1566657193,
+    "wof:lastmodified":1582332145,
     "wof:name":"\uff11\u4e01\u76ee",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/164/27/85916427.geojson
+++ b/data/859/164/27/85916427.geojson
@@ -79,6 +79,9 @@
         "qs_pg:id":1276408
     },
     "wof:country":"",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"118ef90bd37c8503e13fec1ae0cc5cdd",
     "wof:hierarchy":[
         {
@@ -94,7 +97,7 @@
     "wof:lang":[
         "jpn"
     ],
-    "wof:lastmodified":1566657200,
+    "wof:lastmodified":1582332146,
     "wof:name":"\uff12\u4e01\u76ee",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/177/65/85917765.geojson
+++ b/data/859/177/65/85917765.geojson
@@ -79,6 +79,9 @@
         "qs_pg:id":996107
     },
     "wof:country":"",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"561fd8a1130ce6c2e7b440957f699fe5",
     "wof:hierarchy":[
         {
@@ -94,7 +97,7 @@
     "wof:lang":[
         "jpn"
     ],
-    "wof:lastmodified":1566657205,
+    "wof:lastmodified":1582332147,
     "wof:name":"\uff11\u4e01\u76ee",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/178/95/85917895.geojson
+++ b/data/859/178/95/85917895.geojson
@@ -80,6 +80,9 @@
         "qs_pg:id":64832
     },
     "wof:country":"",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"3c384a4a4b07b4646cdcfec647ed480e",
     "wof:hierarchy":[
         {
@@ -95,7 +98,7 @@
     "wof:lang":[
         "jpn"
     ],
-    "wof:lastmodified":1566657205,
+    "wof:lastmodified":1582332147,
     "wof:name":"\uff13\u4e01\u76ee",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/182/77/85918277.geojson
+++ b/data/859/182/77/85918277.geojson
@@ -79,6 +79,9 @@
         "qs_pg:id":911684
     },
     "wof:country":"",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"719117f104316287a55f60ba8491fdb8",
     "wof:hierarchy":[
         {
@@ -94,7 +97,7 @@
     "wof:lang":[
         "jpn"
     ],
-    "wof:lastmodified":1566657205,
+    "wof:lastmodified":1582332147,
     "wof:name":"\uff13\u4e01\u76ee",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/186/65/85918665.geojson
+++ b/data/859/186/65/85918665.geojson
@@ -78,6 +78,10 @@
         "qs_pg:id":1281430
     },
     "wof:country":"",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"8e37d251241ca010e6383e933387b525",
     "wof:hierarchy":[
         {
@@ -92,7 +96,7 @@
     "wof:lang":[
         "jpn"
     ],
-    "wof:lastmodified":1566657199,
+    "wof:lastmodified":1582332146,
     "wof:name":"\uff17\u4e01\u76ee",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/191/41/85919141.geojson
+++ b/data/859/191/41/85919141.geojson
@@ -79,6 +79,9 @@
         "qs_pg:id":1110765
     },
     "wof:country":"",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"35fc0922cd887f016c93488964291e1b",
     "wof:hierarchy":[
         {
@@ -94,7 +97,7 @@
     "wof:lang":[
         "jpn"
     ],
-    "wof:lastmodified":1566657199,
+    "wof:lastmodified":1582332146,
     "wof:name":"\uff11\u4e01\u76ee",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/192/03/85919203.geojson
+++ b/data/859/192/03/85919203.geojson
@@ -80,6 +80,10 @@
         "qs_pg:id":264811
     },
     "wof:country":"",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"b0eeb3d7bb109f7146f929dcdff4678c",
     "wof:hierarchy":[
         {
@@ -95,7 +99,7 @@
     "wof:lang":[
         "jpn"
     ],
-    "wof:lastmodified":1566657192,
+    "wof:lastmodified":1582332145,
     "wof:name":"\uff18\u4e01\u76ee",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/192/41/85919241.geojson
+++ b/data/859/192/41/85919241.geojson
@@ -79,6 +79,9 @@
         "qs_pg:id":888311
     },
     "wof:country":"",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"a5f2a76540b203c9e5f37cbabc6db8f7",
     "wof:hierarchy":[
         {
@@ -94,7 +97,7 @@
     "wof:lang":[
         "jpn"
     ],
-    "wof:lastmodified":1566657192,
+    "wof:lastmodified":1582332145,
     "wof:name":"\uff17\u4e01\u76ee",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/192/55/85919255.geojson
+++ b/data/859/192/55/85919255.geojson
@@ -79,6 +79,9 @@
         "qs_pg:id":996134
     },
     "wof:country":"",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"ceee5bdcc1579dc065ec0a704ac5719a",
     "wof:hierarchy":[
         {
@@ -94,7 +97,7 @@
     "wof:lang":[
         "jpn"
     ],
-    "wof:lastmodified":1566657192,
+    "wof:lastmodified":1582332145,
     "wof:name":"\uff11\u4e01\u76ee",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/192/61/85919261.geojson
+++ b/data/859/192/61/85919261.geojson
@@ -80,6 +80,10 @@
         "qs_pg:id":65194
     },
     "wof:country":"",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"3756605e6d51cc7fedd586ecd796fea7",
     "wof:hierarchy":[
         {
@@ -95,7 +99,7 @@
     "wof:lang":[
         "jpn"
     ],
-    "wof:lastmodified":1566657192,
+    "wof:lastmodified":1582332145,
     "wof:name":"\uff14\u4e01\u76ee",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/196/11/85919611.geojson
+++ b/data/859/196/11/85919611.geojson
@@ -77,6 +77,10 @@
         "qs_pg:id":990931
     },
     "wof:country":"",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"97f248584ac53cf413d7d983ba7f6ffc",
     "wof:hierarchy":[
         {
@@ -91,7 +95,7 @@
     "wof:lang":[
         "jpn"
     ],
-    "wof:lastmodified":1566657199,
+    "wof:lastmodified":1582332146,
     "wof:name":"\uff13\u4e01\u76ee",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/197/77/85919777.geojson
+++ b/data/859/197/77/85919777.geojson
@@ -87,6 +87,10 @@
         "qs_pg:id":1119865
     },
     "wof:country":"",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"a12ef30cfd7a2cf7cd6bf6f7a1178762",
     "wof:hierarchy":[
         {
@@ -102,7 +106,7 @@
     "wof:lang":[
         "jpn"
     ],
-    "wof:lastmodified":1566657200,
+    "wof:lastmodified":1582332146,
     "wof:name":"\uff11\u4e01\u76ee",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/203/41/85920341.geojson
+++ b/data/859/203/41/85920341.geojson
@@ -77,6 +77,10 @@
         "qs_pg:id":907468
     },
     "wof:country":"",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"76c55ca41cac0e39ce9386093548db66",
     "wof:hierarchy":[
         {
@@ -91,7 +95,7 @@
     "wof:lang":[
         "jpn"
     ],
-    "wof:lastmodified":1566657195,
+    "wof:lastmodified":1582332145,
     "wof:name":"\uff11\u4e01\u76ee",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/203/51/85920351.geojson
+++ b/data/859/203/51/85920351.geojson
@@ -79,6 +79,9 @@
         "qs_pg:id":907469
     },
     "wof:country":"",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"0cb872cf99603120270d9297edcb097c",
     "wof:hierarchy":[
         {
@@ -94,7 +97,7 @@
     "wof:lang":[
         "jpn"
     ],
-    "wof:lastmodified":1566657195,
+    "wof:lastmodified":1582332145,
     "wof:name":"\uff12\u4e01\u76ee",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/204/83/85920483.geojson
+++ b/data/859/204/83/85920483.geojson
@@ -80,6 +80,9 @@
         "qs_pg:id":1285527
     },
     "wof:country":"",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"08c085945b5660e94d44cd8d0a63d3f1",
     "wof:hierarchy":[
         {
@@ -95,7 +98,7 @@
     "wof:lang":[
         "jpn"
     ],
-    "wof:lastmodified":1566657195,
+    "wof:lastmodified":1582332145,
     "wof:name":"\uff13\u4e01\u76ee",
     "wof:parent_id":102031835,
     "wof:placetype":"neighbourhood",

--- a/data/859/208/73/85920873.geojson
+++ b/data/859/208/73/85920873.geojson
@@ -79,6 +79,9 @@
         "qs_pg:id":903161
     },
     "wof:country":"",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"2ccb4935d6d3fe7b9fb0d29f1076ec8a",
     "wof:hierarchy":[
         {
@@ -94,7 +97,7 @@
     "wof:lang":[
         "jpn"
     ],
-    "wof:lastmodified":1566657204,
+    "wof:lastmodified":1582332147,
     "wof:name":"\uff12\u4e01\u76ee",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/208/95/85920895.geojson
+++ b/data/859/208/95/85920895.geojson
@@ -79,6 +79,9 @@
         "qs_pg:id":241994
     },
     "wof:country":"",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"85ffa5e4c4a09961d22838facbcc577d",
     "wof:hierarchy":[
         {
@@ -94,7 +97,7 @@
     "wof:lang":[
         "jpn"
     ],
-    "wof:lastmodified":1566657204,
+    "wof:lastmodified":1582332147,
     "wof:name":"\uff13\u4e01\u76ee",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/220/43/85922043.geojson
+++ b/data/859/220/43/85922043.geojson
@@ -67,6 +67,9 @@
         "qs_pg:id":899189
     },
     "wof:country":"",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"565bf613970e0407f8cc99f424db4c63",
     "wof:hierarchy":[
         {
@@ -82,7 +85,7 @@
     "wof:lang":[
         "chi"
     ],
-    "wof:lastmodified":1566657193,
+    "wof:lastmodified":1582332145,
     "wof:name":"\u76db\u660c\u91cc",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/220/67/85922067.geojson
+++ b/data/859/220/67/85922067.geojson
@@ -66,6 +66,9 @@
         "qs_pg:id":376471
     },
     "wof:country":"",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"8c669e783aef1a745372c413b9016a97",
     "wof:hierarchy":[
         {
@@ -81,7 +84,7 @@
     "wof:lang":[
         "chi"
     ],
-    "wof:lastmodified":1566657193,
+    "wof:lastmodified":1582332145,
     "wof:name":"\u56db\u8349\u91cc",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/221/55/85922155.geojson
+++ b/data/859/221/55/85922155.geojson
@@ -66,6 +66,9 @@
         "qs_pg:id":1340592
     },
     "wof:country":"",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"bb7642ce0a52a6a82d19284b15cea2d8",
     "wof:hierarchy":[
         {
@@ -81,7 +84,7 @@
     "wof:lang":[
         "chi"
     ],
-    "wof:lastmodified":1566657194,
+    "wof:lastmodified":1582332145,
     "wof:name":"\u897f\u8ce2\u91cc",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/222/79/85922279.geojson
+++ b/data/859/222/79/85922279.geojson
@@ -66,6 +66,9 @@
         "qs_pg:id":376566
     },
     "wof:country":"",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"6db00e6046f985217a031091f323b4b1",
     "wof:hierarchy":[
         {
@@ -81,7 +84,7 @@
     "wof:lang":[
         "chi"
     ],
-    "wof:lastmodified":1566657203,
+    "wof:lastmodified":1582332146,
     "wof:name":"\u570b\u5b89\u91cc",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/223/19/85922319.geojson
+++ b/data/859/223/19/85922319.geojson
@@ -66,6 +66,9 @@
         "qs_pg:id":1065263
     },
     "wof:country":"",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"c57b9e89ff252c38ef2e151899643034",
     "wof:hierarchy":[
         {
@@ -81,7 +84,7 @@
     "wof:lang":[
         "chi"
     ],
-    "wof:lastmodified":1566657202,
+    "wof:lastmodified":1582332146,
     "wof:name":"\u5927\u6e2f\u91cc",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/223/63/85922363.geojson
+++ b/data/859/223/63/85922363.geojson
@@ -66,6 +66,9 @@
         "qs_pg:id":474687
     },
     "wof:country":"",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"3c8f29beea9562fa18ecb39a56360933",
     "wof:hierarchy":[
         {
@@ -81,7 +84,7 @@
     "wof:lang":[
         "chi"
     ],
-    "wof:lastmodified":1566657202,
+    "wof:lastmodified":1582332146,
     "wof:name":"\u9e7d\u7530\u91cc",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/257/13/85925713.geojson
+++ b/data/859/257/13/85925713.geojson
@@ -77,6 +77,10 @@
         "qs_pg:id":1002989
     },
     "wof:country":"",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"979593072f1ec71bdd9174cc06cf1b8d",
     "wof:hierarchy":[
         {
@@ -92,7 +96,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566657195,
+    "wof:lastmodified":1582332145,
     "wof:name":"\ub2a5\uace1\ub3d9",
     "wof:parent_id":102026411,
     "wof:placetype":"neighbourhood",

--- a/data/859/296/47/85929647.geojson
+++ b/data/859/296/47/85929647.geojson
@@ -77,6 +77,9 @@
         "wd:id":"Q8053382"
     },
     "wof:country":"",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"2536e778e3ed3f0de59d9d84b6b4da4f",
     "wof:hierarchy":[
         {
@@ -92,7 +95,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566657204,
+    "wof:lastmodified":1582332147,
     "wof:name":"Ye\u015filtepe",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/298/53/85929853.geojson
+++ b/data/859/298/53/85929853.geojson
@@ -86,6 +86,9 @@
         "wd:id":"Q483717"
     },
     "wof:country":"",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"6a7c68d3f9f4602422a6e1cce3257a83",
     "wof:hierarchy":[
         {
@@ -98,7 +101,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566657204,
+    "wof:lastmodified":1582332146,
     "wof:name":"Anadolu Kavagi",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/303/97/85930397.geojson
+++ b/data/859/303/97/85930397.geojson
@@ -78,6 +78,10 @@
         "qs_pg:id":473637
     },
     "wof:country":"",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"e206955a25f0ee2ad8ebd0c7c8641e9a",
     "wof:hierarchy":[
         {
@@ -93,7 +97,7 @@
     "wof:lang":[
         "ara"
     ],
-    "wof:lastmodified":1566657200,
+    "wof:lastmodified":1582332146,
     "wof:name":"\u0627\u0644\u062a\u062c\u0645\u0639 121",
     "wof:parent_id":421174961,
     "wof:placetype":"neighbourhood",

--- a/data/859/304/33/85930433.geojson
+++ b/data/859/304/33/85930433.geojson
@@ -74,6 +74,10 @@
         "qs_pg:id":986683
     },
     "wof:country":"",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"d7c4088714489d13beeff49b771103f3",
     "wof:hierarchy":[
         {
@@ -89,7 +93,7 @@
     "wof:lang":[
         "ara"
     ],
-    "wof:lastmodified":1566657200,
+    "wof:lastmodified":1582332146,
     "wof:name":"\u0627\u0644\u0631\u0648\u0644",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/306/27/85930627.geojson
+++ b/data/859/306/27/85930627.geojson
@@ -78,6 +78,10 @@
         "qs_pg:id":1120072
     },
     "wof:country":"",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"a9f301d2f4cb487e92a73c96c488f9ec",
     "wof:hierarchy":[
         {
@@ -93,7 +97,7 @@
     "wof:lang":[
         "ara"
     ],
-    "wof:lastmodified":1566657192,
+    "wof:lastmodified":1582332145,
     "wof:name":"\u0627\u0644\u0645\u062c\u0627\u0632 3",
     "wof:parent_id":421168683,
     "wof:placetype":"neighbourhood",

--- a/data/859/321/79/85932179.geojson
+++ b/data/859/321/79/85932179.geojson
@@ -74,6 +74,10 @@
         "qs_pg:id":1090206
     },
     "wof:country":"",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"22d561df1d995aa68077aa2102bd69cf",
     "wof:hierarchy":[
         {
@@ -88,7 +92,7 @@
     "wof:lang":[
         "ara"
     ],
-    "wof:lastmodified":1566657205,
+    "wof:lastmodified":1582332147,
     "wof:name":"\u0645\u062c\u0645\u0639 241",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/322/27/85932227.geojson
+++ b/data/859/322/27/85932227.geojson
@@ -66,6 +66,10 @@
         "qs_pg:id":1295836
     },
     "wof:country":"",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"c209f7bc16f8b777e81d4288a5d548c7",
     "wof:hierarchy":[
         {
@@ -80,7 +84,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566657199,
+    "wof:lastmodified":1582332146,
     "wof:name":"Muharraq City-block 202",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/323/21/85932321.geojson
+++ b/data/859/323/21/85932321.geojson
@@ -66,6 +66,10 @@
         "qs_pg:id":986743
     },
     "wof:country":"",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"4baf4b0104193cc5cd0866aad9d02228",
     "wof:hierarchy":[
         {
@@ -80,7 +84,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566657198,
+    "wof:lastmodified":1582332146,
     "wof:name":"Salmiya-block 6",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/324/35/85932435.geojson
+++ b/data/859/324/35/85932435.geojson
@@ -66,6 +66,10 @@
         "qs_pg:id":996315
     },
     "wof:country":"",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"09b0822c1e4eb74f6d0c499afd09a0f7",
     "wof:hierarchy":[
         {
@@ -80,7 +84,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566657198,
+    "wof:lastmodified":1582332146,
     "wof:name":"Salwa-block 11",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/324/79/85932479.geojson
+++ b/data/859/324/79/85932479.geojson
@@ -66,6 +66,10 @@
         "qs_pg:id":467836
     },
     "wof:country":"",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"75560a508bb2d2aca574f8b59158707b",
     "wof:hierarchy":[
         {
@@ -80,7 +84,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566657198,
+    "wof:lastmodified":1582332146,
     "wof:name":"Salmiya-block 4",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/324/97/85932497.geojson
+++ b/data/859/324/97/85932497.geojson
@@ -73,6 +73,10 @@
         "qs_pg:id":467839
     },
     "wof:country":"",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"ed1538ed23539291aeb37f2a6ab0452a",
     "wof:hierarchy":[
         {
@@ -87,7 +91,7 @@
     "wof:lang":[
         "ara"
     ],
-    "wof:lastmodified":1566657198,
+    "wof:lastmodified":1582332146,
     "wof:name":"\u0627\u0644\u0633\u0627\u0644\u0645\u064a\u0629-\u0642\u0637\u0639\u0629 9",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/325/33/85932533.geojson
+++ b/data/859/325/33/85932533.geojson
@@ -69,6 +69,10 @@
         "qs_pg:id":1090203
     },
     "wof:country":"",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"ae390a4d5020e21424be6ec302a04db5",
     "wof:hierarchy":[
         {
@@ -83,7 +87,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566657199,
+    "wof:lastmodified":1582332146,
     "wof:name":"Sharq-block 11",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/325/71/85932571.geojson
+++ b/data/859/325/71/85932571.geojson
@@ -69,6 +69,10 @@
         "qs_pg:id":467841
     },
     "wof:country":"",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"d566f9fef1940d931e2dd0d9751a4e86",
     "wof:hierarchy":[
         {
@@ -83,7 +87,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566657199,
+    "wof:lastmodified":1582332146,
     "wof:name":"Shuwaikh-block 7",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/344/23/85934423.geojson
+++ b/data/859/344/23/85934423.geojson
@@ -64,6 +64,9 @@
         "qs_pg:id":383634
     },
     "wof:country":"",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"e05637e9e7e9f9db8b9e1d338b70827e",
     "wof:hierarchy":[
         {
@@ -78,7 +81,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566657205,
+    "wof:lastmodified":1582332147,
     "wof:name":"Goalghar",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/344/27/85934427.geojson
+++ b/data/859/344/27/85934427.geojson
@@ -67,6 +67,9 @@
         "qs_pg:id":383636
     },
     "wof:country":"",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"b0d532cdf530ada32d29b5e8cc9e4bad",
     "wof:hierarchy":[
         {
@@ -82,7 +85,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566657205,
+    "wof:lastmodified":1582332147,
     "wof:name":"Junglighat",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/346/21/85934621.geojson
+++ b/data/859/346/21/85934621.geojson
@@ -68,6 +68,10 @@
         "qs_pg:id":1346870
     },
     "wof:country":"",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"b489ac6507f4e97a1aad6ac899728589",
     "wof:hierarchy":[
         {
@@ -82,7 +86,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566657197,
+    "wof:lastmodified":1582332146,
     "wof:name":"Bhandarpule",
     "wof:parent_id":102031183,
     "wof:placetype":"neighbourhood",

--- a/data/859/352/65/85935265.geojson
+++ b/data/859/352/65/85935265.geojson
@@ -67,6 +67,10 @@
         "qs_pg:id":1310064
     },
     "wof:country":"",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"4af3e5c8e0b1ed62f7b1b52d23619733",
     "wof:hierarchy":[
         {
@@ -82,7 +86,7 @@
     "wof:lang":[
         "jpn"
     ],
-    "wof:lastmodified":1566657193,
+    "wof:lastmodified":1582332145,
     "wof:name":"\uff08\u4e01\u76ee\u306a\u3057\uff09",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/357/29/85935729.geojson
+++ b/data/859/357/29/85935729.geojson
@@ -81,6 +81,10 @@
         "qs_pg:id":273625
     },
     "wof:country":"",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"09ecaed4494855b174091fbd1947af0e",
     "wof:hierarchy":[
         {
@@ -96,7 +100,7 @@
     "wof:lang":[
         "jpn"
     ],
-    "wof:lastmodified":1566657199,
+    "wof:lastmodified":1582332146,
     "wof:name":"\uff16\u4e01\u76ee",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/890/445/621/890445621.geojson
+++ b/data/890/445/621/890445621.geojson
@@ -380,6 +380,9 @@
     },
     "wof:country":"",
     "wof:created":1469052516,
+    "wof:geom_alt":[
+        "unknown"
+    ],
     "wof:geomhash":"e8e03f1319dbec967d55130df005d047",
     "wof:hierarchy":[
         {
@@ -390,7 +393,7 @@
         }
     ],
     "wof:id":890445621,
-    "wof:lastmodified":1566657572,
+    "wof:lastmodified":1582332154,
     "wof:name":"St. John's",
     "wof:parent_id":85668191,
     "wof:placetype":"locality",

--- a/data/890/451/987/890451987.geojson
+++ b/data/890/451/987/890451987.geojson
@@ -101,6 +101,9 @@
     },
     "wof:country":"",
     "wof:created":1469052800,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"7ac8881630532a67203aa142fa1a07cb",
     "wof:hierarchy":[
         {
@@ -111,7 +114,7 @@
         }
     ],
     "wof:id":890451987,
-    "wof:lastmodified":1566657574,
+    "wof:lastmodified":1582332154,
     "wof:name":"Saida",
     "wof:parent_id":85673499,
     "wof:placetype":"county",

--- a/data/890/452/045/890452045.geojson
+++ b/data/890/452/045/890452045.geojson
@@ -359,6 +359,9 @@
     },
     "wof:country":"",
     "wof:created":1469052802,
+    "wof:geom_alt":[
+        "unknown"
+    ],
     "wof:geomhash":"f9b834a323c7940841c1eadbfdb8e444",
     "wof:hierarchy":[
         {
@@ -369,7 +372,7 @@
         }
     ],
     "wof:id":890452045,
-    "wof:lastmodified":1566657569,
+    "wof:lastmodified":1582332154,
     "wof:name":"Mat\u00e2' Utu",
     "wof:parent_id":85680901,
     "wof:placetype":"locality",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/1793

This PR:

- Adds a new `wof:geom_alt` property to any "default" WOF record that has an alt file, logic [here](https://github.com/whosonfirst-data/whosonfirst-data/issues/1793#issuecomment-587895012)
- Double checks existing `src:geom_alt` properties to ensure all alt file sources are accounted for in the property list. 

This will not require PIP work to update hierarchies.