### PR TITLE
Update names and concordances on neighbourhood record

### DIFF
--- a/data/420/781/217/420781217.geojson
+++ b/data/420/781/217/420781217.geojson
@@ -6,7 +6,7 @@
     "edtf:inception":"uuuu",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
-    "geom:bbox":"-95.9000592739,41.1365701347,-95.9000592739,41.1365701347",
+    "geom:bbox":"-95.900059,41.13657,-95.900059,41.13657",
     "geom:latitude":41.13657,
     "geom:longitude":-95.900059,
     "iso:country":"",
@@ -23,121 +23,24 @@
     "mz:max_zoom":18.0,
     "mz:min_zoom":14.0,
     "mz:tier_locality":0,
-    "name:ara_x_preferred":[
-        "\u0628\u0644\u062f\u0629 \u0642\u062f\u064a\u0645\u0629"
-    ],
-    "name:bel_x_preferred":[
-        "\u0433\u0456\u0441\u0442\u0430\u0440\u044b\u0447\u043d\u044b \u0446\u044d\u043d\u0442\u0440"
-    ],
-    "name:cat_x_preferred":[
-        "centre hist\u00f2ric"
-    ],
-    "name:ces_x_preferred":[
-        "historick\u00e9 j\u00e1dro m\u011bsta"
-    ],
-    "name:deu_x_preferred":[
-        "historischer Stadtkern"
-    ],
-    "name:ell_x_preferred":[
-        "\u03c0\u03b1\u03bb\u03b1\u03b9\u03ac \u03c0\u03cc\u03bb\u03b7"
-    ],
     "name:eng_x_preferred":[
-        "old town"
+        "Olde Towne"
     ],
-    "name:epo_x_preferred":[
-        "historia urboparto"
-    ],
-    "name:est_x_preferred":[
-        "vanalinn"
-    ],
-    "name:eus_x_preferred":[
-        "alde zahar"
-    ],
-    "name:fas_x_preferred":[
-        "\u0634\u0647\u0631\u06a9 \u0642\u062f\u06cc\u0645\u06cc"
-    ],
-    "name:fin_x_preferred":[
-        "Vanhakaupunki"
-    ],
-    "name:fra_x_preferred":[
-        "centre historique"
-    ],
-    "name:gsw_x_preferred":[
-        "Altstadt"
-    ],
-    "name:heb_x_preferred":[
-        "\u05e2\u05d9\u05e8 \u05e2\u05ea\u05d9\u05e7\u05d4"
-    ],
-    "name:hun_x_preferred":[
-        "\u00f3v\u00e1ros"
-    ],
-    "name:ita_x_preferred":[
-        "centro storico"
-    ],
-    "name:jpn_x_preferred":[
-        "\u65e7\u5e02\u8857"
-    ],
-    "name:kor_x_preferred":[
-        "\uad6c\uc2dc\uac00"
-    ],
-    "name:lav_x_preferred":[
-        "vecpils\u0113ta"
-    ],
-    "name:mkd_x_preferred":[
-        "\u0441\u0442\u0430\u0440\u043e \u0433\u0440\u0430\u0434\u0441\u043a\u043e \u0458\u0430\u0434\u0440\u043e"
-    ],
-    "name:nld_x_preferred":[
-        "oude stadskern"
-    ],
-    "name:pol_x_preferred":[
-        "stare miasto"
-    ],
-    "name:por_x_preferred":[
-        "centro hist\u00f3rico"
-    ],
-    "name:ron_x_preferred":[
-        "Centrul istoric"
-    ],
-    "name:rus_x_preferred":[
-        "\u0438\u0441\u0442\u043e\u0440\u0438\u0447\u0435\u0441\u043a\u0438\u0439 \u0446\u0435\u043d\u0442\u0440 \u0433\u043e\u0440\u043e\u0434\u0430"
-    ],
-    "name:sco_x_preferred":[
-        "Auld Toun"
-    ],
-    "name:slk_x_preferred":[
-        "Historick\u00e9 centrum"
-    ],
-    "name:spa_x_preferred":[
-        "casco antiguo"
-    ],
-    "name:srp_x_preferred":[
-        "\u0441\u0442\u0430\u0440\u043e \u0433\u0440\u0430\u0434\u0441\u043a\u043e \u0458\u0435\u0437\u0433\u0440\u043e"
-    ],
-    "name:tur_x_preferred":[
-        "tarihi kent merkezi"
-    ],
-    "name:ukr_x_preferred":[
-        "\u0456\u0441\u0442\u043e\u0440\u0438\u0447\u043d\u0438\u0439 \u0446\u0435\u043d\u0442\u0440 \u043c\u0456\u0441\u0442\u0430"
-    ],
-    "name:zho_x_preferred":[
-        "\u53e4\u8001\u57ce\u9547"
-    ],
+    "src:geom":"unknown",
     "wd:wordcount":1951,
     "wof:belongsto":[
         102191575,
-        404519143,
         85633793,
-        85974545,
         102082777,
+        404519143,
+        85974545,
         85688563
     ],
     "wof:breaches":[],
-    "wof:concordances":{
-        "wd:id":"Q676050"
-    },
+    "wof:concordances":{},
     "wof:country":"",
     "wof:created":1458871783,
-    "wof:geomhash":"d01466dcdbd0c3f7b73f52b9a7557a1c",
+    "wof:geomhash":"e495c40862d6ca4e50cd46338ac0730a",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -150,7 +53,7 @@
         }
     ],
     "wof:id":420781217,
-    "wof:lastmodified":1566657520,
+    "wof:lastmodified":1652294071,
     "wof:name":"Olde Towne",
     "wof:parent_id":85974545,
     "wof:placetype":"neighbourhood",
@@ -160,10 +63,10 @@
     "wof:tags":[]
 },
   "bbox": [
-    -95.90005927390287,
-    41.13657013467704,
-    -95.90005927390287,
-    41.13657013467704
+    -95.900059,
+    41.13657,
+    -95.900059,
+    41.13657
 ],
-  "geometry": {"coordinates":[-95.90005927390287,41.13657013467704],"type":"Point"}
+  "geometry": {"coordinates":[-95.900059,41.13657],"type":"Point"}
 }


### PR DESCRIPTION
This PR corrects the Olde Towne neighbourhood record, removing bogus name properties, correcting the `name:eng_x_preferred` property, and removing the Wikidata concordance that was used to import these names in the first place.