### PR TITLE
Update French name properties on ocean records

### DIFF
--- a/data/404/528/709/404528709.geojson
+++ b/data/404/528/709/404528709.geojson
@@ -14,7 +14,7 @@
     "lbl:longitude":-30.723679,
     "lbl:max_zoom":10.0,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:max_zoom":6.5,
     "mz:min_zoom":1.0,
     "name:abk_x_preferred":[
@@ -210,10 +210,11 @@
         "Atlantin valtameri"
     ],
     "name:fra_x_preferred":[
-        "Ocean Atlantique Nord"
+        "Oc\u00e9an Atlantique Nord"
     ],
     "name:fra_x_variant":[
-        "oc\u00e9an Atlantique"
+        "oc\u00e9an Atlantique",
+        "Ocean Atlantique Nord"
     ],
     "name:frp_x_preferred":[
         "Oc\u00e8an Atlantico"
@@ -789,7 +790,7 @@
         }
     ],
     "wof:id":404528709,
-    "wof:lastmodified":1587428880,
+    "wof:lastmodified":1675966250,
     "wof:name":"North Atlantic Ocean",
     "wof:parent_id":-1,
     "wof:placetype":"ocean",

--- a/data/404/528/711/404528711.geojson
+++ b/data/404/528/711/404528711.geojson
@@ -14,7 +14,7 @@
     "lbl:longitude":-136.470534,
     "lbl:max_zoom":10.0,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:max_zoom":6.5,
     "mz:min_zoom":1.0,
     "name:abk_x_preferred":[
@@ -204,10 +204,11 @@
         "Tyynimeri"
     ],
     "name:fra_x_preferred":[
-        "Ocean Pacifique Nord"
+        "Oc\u00e9an Pacifique Nord"
     ],
     "name:fra_x_variant":[
-        "oc\u00e9an Pacifique"
+        "oc\u00e9an Pacifique",
+        "Ocean Pacifique Nord"
     ],
     "name:frp_x_preferred":[
         "Oc\u00e8an Pacefico"
@@ -780,7 +781,7 @@
         }
     ],
     "wof:id":404528711,
-    "wof:lastmodified":1587428911,
+    "wof:lastmodified":1675966255,
     "wof:name":"North Pacific Ocean",
     "wof:parent_id":-1,
     "wof:placetype":"ocean",

--- a/data/404/528/713/404528713.geojson
+++ b/data/404/528/713/404528713.geojson
@@ -14,7 +14,7 @@
     "lbl:longitude":-126.821753,
     "lbl:max_zoom":10.0,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:max_zoom":6.5,
     "mz:min_zoom":1.0,
     "name:abk_x_preferred":[
@@ -204,10 +204,11 @@
         "Tyynimeri"
     ],
     "name:fra_x_preferred":[
-        "Ocean Pacifique Sud"
+        "Oc\u00e9an Pacifique Sud"
     ],
     "name:fra_x_variant":[
-        "oc\u00e9an Pacifique"
+        "oc\u00e9an Pacifique",
+        "Ocean Pacifique Sud"
     ],
     "name:frp_x_preferred":[
         "Oc\u00e8an Pacefico"
@@ -780,7 +781,7 @@
         }
     ],
     "wof:id":404528713,
-    "wof:lastmodified":1587428888,
+    "wof:lastmodified":1675966257,
     "wof:name":"South Pacific Ocean",
     "wof:parent_id":-1,
     "wof:placetype":"ocean",

--- a/data/404/528/717/404528717.geojson
+++ b/data/404/528/717/404528717.geojson
@@ -189,10 +189,11 @@
         "Intian valtameri"
     ],
     "name:fra_x_preferred":[
-        "Ocean Indien"
+        "Oc\u00e9an Indien"
     ],
     "name:fra_x_variant":[
-        "oc\u00e9an Indien"
+        "oc\u00e9an Indien",
+        "Ocean Indien"
     ],
     "name:frp_x_preferred":[
         "Oc\u00e8an Endien"
@@ -687,7 +688,7 @@
         }
     ],
     "wof:id":404528717,
-    "wof:lastmodified":1654281664,
+    "wof:lastmodified":1675966259,
     "wof:name":"Indian Ocean",
     "wof:parent_id":-1,
     "wof:placetype":"ocean",

--- a/data/404/528/719/404528719.geojson
+++ b/data/404/528/719/404528719.geojson
@@ -14,7 +14,7 @@
     "lbl:longitude":-18.309926,
     "lbl:max_zoom":10.0,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:max_zoom":6.5,
     "mz:min_zoom":1.0,
     "name:abk_x_preferred":[
@@ -210,10 +210,11 @@
         "Atlantin valtameri"
     ],
     "name:fra_x_preferred":[
-        "Ocean Atlantique Sud"
+        "Oc\u00e9an Atlantique Sud"
     ],
     "name:fra_x_variant":[
-        "oc\u00e9an Atlantique"
+        "oc\u00e9an Atlantique",
+        "Ocean Atlantique Sud"
     ],
     "name:frp_x_preferred":[
         "Oc\u00e8an Atlantico"
@@ -789,7 +790,7 @@
         }
     ],
     "wof:id":404528719,
-    "wof:lastmodified":1587428907,
+    "wof:lastmodified":1675966261,
     "wof:name":"South Atlantic Ocean",
     "wof:parent_id":-1,
     "wof:placetype":"ocean",


### PR DESCRIPTION
This PR updates `name:fra_*` properties on ocean records in Who's On First. French preferred names were updated to include "Océan" and existing French preferred names were demoted to variant properties.

No PIP work needed. Note the [Arctic Ocean](https://spelunker.whosonfirst.org/id/404528705/) record is okay as-is.

See also
https://fr.wikipedia.org/wiki/Oc%C3%A9an_Pacifique
https://fr.wikipedia.org/wiki/Oc%C3%A9an_Atlantique