### PR TITLE
xy concordances, placetype local, and more

### DIFF
--- a/data/890/438/023/890438023.geojson
+++ b/data/890/438/023/890438023.geojson
@@ -54,7 +54,7 @@
         }
     ],
     "wof:id":890438023,
-    "wof:lastmodified":1694492294,
+    "wof:lastmodified":1695887130,
     "wof:name":"\u0643\u0644\u0628\u0627\u0621",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/890/440/801/890440801.geojson
+++ b/data/890/440/801/890440801.geojson
@@ -63,7 +63,7 @@
         }
     ],
     "wof:id":890440801,
-    "wof:lastmodified":1694492300,
+    "wof:lastmodified":1695887128,
     "wof:name":"Ituau",
     "wof:parent_id":85668127,
     "wof:placetype":"county",

--- a/data/890/440/837/890440837.geojson
+++ b/data/890/440/837/890440837.geojson
@@ -10,7 +10,7 @@
     "geom:latitude":-21.10484,
     "geom:longitude":164.887275,
     "gp:adm0":23424903,
-    "iso:country":"",
+    "iso:country":"NC",
     "label:eng_x_preferred_longname":[
         "Pouembout County"
     ],
@@ -278,10 +278,10 @@
     "qs:pop_sr":"0",
     "wd:wordcount":20,
     "wof:belongsto":[
-        102191583,
         85632473,
-        136253037,
-        85675261
+        85675261,
+        102191583,
+        136253037
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -290,9 +290,9 @@
         "wd:id":"Q9744",
         "wk:page":"Pouembout"
     },
-    "wof:country":"",
+    "wof:country":"NC",
     "wof:created":1469052299,
-    "wof:geomhash":"1dd3b9c3b8b6e39a0cc9b62ed92e89ee",
+    "wof:geomhash":"6ade468d0a78021f462fe1541da9cbdb",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -304,7 +304,7 @@
         }
     ],
     "wof:id":890440837,
-    "wof:lastmodified":1599258503,
+    "wof:lastmodified":1695887130,
     "wof:name":"Pouembout",
     "wof:parent_id":85675261,
     "wof:placetype":"county",

--- a/data/890/440/841/890440841.geojson
+++ b/data/890/440/841/890440841.geojson
@@ -10,7 +10,7 @@
     "geom:latitude":-21.607482,
     "geom:longitude":165.456848,
     "gp:adm0":23424903,
-    "iso:country":"",
+    "iso:country":"NC",
     "label:eng_x_preferred_longname":[
         "Bourail County"
     ],
@@ -292,9 +292,9 @@
         "wd:id":"Q9709",
         "wk:page":"Bourail"
     },
-    "wof:country":"",
+    "wof:country":"NC",
     "wof:created":1469052299,
-    "wof:geomhash":"e68afaf0106f5c1791dedf57c9e12755",
+    "wof:geomhash":"cd56af6e94c0e882698b98549ffc63d1",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -306,7 +306,7 @@
         }
     ],
     "wof:id":890440841,
-    "wof:lastmodified":1690923869,
+    "wof:lastmodified":1695887130,
     "wof:name":"Bourail",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/890/441/223/890441223.geojson
+++ b/data/890/441/223/890441223.geojson
@@ -10,7 +10,7 @@
     "geom:latitude":-20.241582,
     "geom:longitude":164.094457,
     "gp:adm0":23424903,
-    "iso:country":"",
+    "iso:country":"NC",
     "label:eng_x_preferred_longname":[
         "Poum County"
     ],
@@ -74,7 +74,7 @@
         "gp:id":24551438,
         "qs_pg:id":1263463
     },
-    "wof:country":"",
+    "wof:country":"NC",
     "wof:created":1469052314,
     "wof:geomhash":"e9fe569131355da3b82c74e34c32a19b",
     "wof:hierarchy":[
@@ -88,7 +88,7 @@
         }
     ],
     "wof:id":890441223,
-    "wof:lastmodified":1694492294,
+    "wof:lastmodified":1695887130,
     "wof:name":"Poum",
     "wof:parent_id":85675261,
     "wof:placetype":"county",

--- a/data/890/441/225/890441225.geojson
+++ b/data/890/441/225/890441225.geojson
@@ -298,7 +298,7 @@
     },
     "wof:country":"",
     "wof:created":1469052314,
-    "wof:geomhash":"fad47b47021bf43cfb93af54b6d3a8e2",
+    "wof:geomhash":"2305d788efad95296c6743a6c3360a96",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -309,7 +309,7 @@
         }
     ],
     "wof:id":890441225,
-    "wof:lastmodified":1690923877,
+    "wof:lastmodified":1695887130,
     "wof:name":"Hienghene",
     "wof:parent_id":85675261,
     "wof:placetype":"county",

--- a/data/890/441/229/890441229.geojson
+++ b/data/890/441/229/890441229.geojson
@@ -71,7 +71,7 @@
         }
     ],
     "wof:id":890441229,
-    "wof:lastmodified":1694492824,
+    "wof:lastmodified":1695886232,
     "wof:name":"Coral Bay",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/890/441/239/890441239.geojson
+++ b/data/890/441/239/890441239.geojson
@@ -122,7 +122,7 @@
     },
     "wof:country":"",
     "wof:created":1469052315,
-    "wof:geomhash":"15cc111a96924bf101d912309bccaeb6",
+    "wof:geomhash":"7ab96d1aa0a75939049ee8cd1431e19f",
     "wof:hierarchy":[
         {
             "continent_id":-1,
@@ -131,7 +131,7 @@
         }
     ],
     "wof:id":890441239,
-    "wof:lastmodified":1636497531,
+    "wof:lastmodified":1695884286,
     "wof:name":"Kwajalein",
     "wof:parent_id":-1,
     "wof:placetype":"region",

--- a/data/890/441/241/890441241.geojson
+++ b/data/890/441/241/890441241.geojson
@@ -395,7 +395,7 @@
     },
     "wof:country":"",
     "wof:created":1469052315,
-    "wof:geomhash":"920cd32f9d8f4953f2c464eff32c33f0",
+    "wof:geomhash":"ddd796d16750ff58f8d101957fc42eab",
     "wof:hierarchy":[
         {
             "continent_id":-1,
@@ -404,7 +404,7 @@
         }
     ],
     "wof:id":890441241,
-    "wof:lastmodified":1690923877,
+    "wof:lastmodified":1695884286,
     "wof:name":"Majuro",
     "wof:parent_id":-1,
     "wof:placetype":"region",

--- a/data/890/441/459/890441459.geojson
+++ b/data/890/441/459/890441459.geojson
@@ -155,7 +155,7 @@
     },
     "wof:country":"",
     "wof:created":1469052324,
-    "wof:geomhash":"795598812410a1bd61b19f175a2f881a",
+    "wof:geomhash":"ed20b9527acf2de9be4a87d51b90a725",
     "wof:hierarchy":[
         {
             "continent_id":-1,
@@ -164,7 +164,7 @@
         }
     ],
     "wof:id":890441459,
-    "wof:lastmodified":1690923879,
+    "wof:lastmodified":1695884286,
     "wof:name":"West Falkland",
     "wof:parent_id":-1,
     "wof:placetype":"region",

--- a/data/890/441/461/890441461.geojson
+++ b/data/890/441/461/890441461.geojson
@@ -52,7 +52,7 @@
     },
     "wof:country":"",
     "wof:created":1469052324,
-    "wof:geomhash":"84e810f7b67f9c59bfb00cd1d2c03914",
+    "wof:geomhash":"bc5ecb1c3336f46d2cb37dec70fc098d",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -63,7 +63,7 @@
         }
     ],
     "wof:id":890441461,
-    "wof:lastmodified":1627523011,
+    "wof:lastmodified":1695884285,
     "wof:name":"Inarajan",
     "wof:parent_id":85632163,
     "wof:placetype":"region",

--- a/data/890/441/463/890441463.geojson
+++ b/data/890/441/463/890441463.geojson
@@ -10,7 +10,7 @@
     "geom:latitude":-20.575903,
     "geom:longitude":166.56063,
     "gp:adm0":23424903,
-    "iso:country":"",
+    "iso:country":"NC",
     "label:eng_x_preferred_longname":[
         "Ouvea County"
     ],
@@ -311,9 +311,9 @@
         "wd:id":"Q10383944",
         "wk:page":"Ouv\u00e9a"
     },
-    "wof:country":"",
+    "wof:country":"NC",
     "wof:created":1469052324,
-    "wof:geomhash":"5dc6969bfd9e4eff4493b33b8e4dc39d",
+    "wof:geomhash":"0256b6b9f4be079293f081b0ffef155b",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -324,7 +324,7 @@
         }
     ],
     "wof:id":890441463,
-    "wof:lastmodified":1690923875,
+    "wof:lastmodified":1695887130,
     "wof:name":"Ouvea",
     "wof:parent_id":85675251,
     "wof:placetype":"county",

--- a/data/890/441/465/890441465.geojson
+++ b/data/890/441/465/890441465.geojson
@@ -10,7 +10,7 @@
     "geom:latitude":-20.727688,
     "geom:longitude":165.068206,
     "gp:adm0":23424903,
-    "iso:country":"",
+    "iso:country":"NC",
     "label:eng_x_preferred_longname":[
         "Voh County"
     ],
@@ -285,9 +285,9 @@
         "wd:id":"Q9757",
         "wk:page":"Voh"
     },
-    "wof:country":"",
+    "wof:country":"NC",
     "wof:created":1469052324,
-    "wof:geomhash":"3defb3f49320b9b235d6071291eafcd9",
+    "wof:geomhash":"1349ce7ccd893f487f600124b8e05af5",
     "wof:hierarchy":[
         {
             "continent_id":-1,
@@ -297,7 +297,7 @@
         }
     ],
     "wof:id":890441465,
-    "wof:lastmodified":1599258503,
+    "wof:lastmodified":1695887130,
     "wof:name":"Voh",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/890/441/825/890441825.geojson
+++ b/data/890/441/825/890441825.geojson
@@ -126,7 +126,7 @@
     },
     "wof:country":"",
     "wof:created":1469052338,
-    "wof:geomhash":"6feea50734c6e0746c73e68a41e22f0b",
+    "wof:geomhash":"4c393c2516d5402f3e03414fba2b3943",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -138,7 +138,7 @@
         }
     ],
     "wof:id":890441825,
-    "wof:lastmodified":1636497531,
+    "wof:lastmodified":1695887148,
     "wof:name":"East End",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/890/441/827/890441827.geojson
+++ b/data/890/441/827/890441827.geojson
@@ -83,7 +83,7 @@
         }
     ],
     "wof:id":890441827,
-    "wof:lastmodified":1694492824,
+    "wof:lastmodified":1695886232,
     "wof:name":"Charlotte Amalie",
     "wof:parent_id":85680571,
     "wof:placetype":"county",

--- a/data/890/441/831/890441831.geojson
+++ b/data/890/441/831/890441831.geojson
@@ -295,7 +295,7 @@
     },
     "wof:country":"",
     "wof:created":1469052338,
-    "wof:geomhash":"c7c1185aaf3a08aaa26679ad26570bdf",
+    "wof:geomhash":"f8a6624325042bf955049da3fe532c4e",
     "wof:hierarchy":[
         {
             "continent_id":-1,
@@ -305,7 +305,7 @@
         }
     ],
     "wof:id":890441831,
-    "wof:lastmodified":1690923878,
+    "wof:lastmodified":1695887130,
     "wof:name":"Moorea-Maiao",
     "wof:parent_id":85676727,
     "wof:placetype":"county",

--- a/data/890/441/833/890441833.geojson
+++ b/data/890/441/833/890441833.geojson
@@ -184,7 +184,7 @@
     },
     "wof:country":"",
     "wof:created":1469052338,
-    "wof:geomhash":"e2b53a35be6a0369423a764e2ae6baea",
+    "wof:geomhash":"e807caf615b3d9528b14808fa02698e7",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -196,7 +196,7 @@
         }
     ],
     "wof:id":890441833,
-    "wof:lastmodified":1690923876,
+    "wof:lastmodified":1695887148,
     "wof:name":"Hiva Oa",
     "wof:parent_id":85676745,
     "wof:placetype":"county",

--- a/data/890/441/835/890441835.geojson
+++ b/data/890/441/835/890441835.geojson
@@ -178,7 +178,7 @@
     },
     "wof:country":"",
     "wof:created":1469052339,
-    "wof:geomhash":"2cb8245528270d57ef7ffaaadef98056",
+    "wof:geomhash":"a2181e9d65367391f40eae22cef16eed",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -190,7 +190,7 @@
         }
     ],
     "wof:id":890441835,
-    "wof:lastmodified":1690923875,
+    "wof:lastmodified":1695887148,
     "wof:name":"Nuku Hiva",
     "wof:parent_id":85676745,
     "wof:placetype":"county",

--- a/data/890/441/839/890441839.geojson
+++ b/data/890/441/839/890441839.geojson
@@ -138,7 +138,7 @@
         }
     ],
     "wof:id":890441839,
-    "wof:lastmodified":1694639681,
+    "wof:lastmodified":1695887130,
     "wof:name":"Matn",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/890/442/021/890442021.geojson
+++ b/data/890/442/021/890442021.geojson
@@ -61,7 +61,7 @@
         }
     ],
     "wof:id":890442021,
-    "wof:lastmodified":1694639832,
+    "wof:lastmodified":1695884328,
     "wof:name":"Kowloon",
     "wof:parent_id":1159397229,
     "wof:placetype":"region",

--- a/data/890/442/843/890442843.geojson
+++ b/data/890/442/843/890442843.geojson
@@ -52,7 +52,7 @@
     },
     "wof:country":"",
     "wof:created":1469052381,
-    "wof:geomhash":"6bedb7c25d4847f1e418c52fa4311cb2",
+    "wof:geomhash":"62f58d744b609df654916492b0637153",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -63,7 +63,7 @@
         }
     ],
     "wof:id":890442843,
-    "wof:lastmodified":1627523011,
+    "wof:lastmodified":1695884285,
     "wof:name":"Sinajana",
     "wof:parent_id":85632163,
     "wof:placetype":"region",

--- a/data/890/442/845/890442845.geojson
+++ b/data/890/442/845/890442845.geojson
@@ -86,7 +86,7 @@
         }
     ],
     "wof:id":890442845,
-    "wof:lastmodified":1694492824,
+    "wof:lastmodified":1695886233,
     "wof:name":"Southside",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/890/442/875/890442875.geojson
+++ b/data/890/442/875/890442875.geojson
@@ -57,7 +57,7 @@
         }
     ],
     "wof:id":890442875,
-    "wof:lastmodified":1694492302,
+    "wof:lastmodified":1695887129,
     "wof:name":"Vaifanua",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/890/442/889/890442889.geojson
+++ b/data/890/442/889/890442889.geojson
@@ -10,7 +10,7 @@
     "geom:latitude":-20.894739,
     "geom:longitude":167.239379,
     "gp:adm0":23424903,
-    "iso:country":"",
+    "iso:country":"NC",
     "label:eng_x_preferred_longname":[
         "Lifou County"
     ],
@@ -308,9 +308,9 @@
         "wd:id":"Q9728",
         "wk:page":"Lifou"
     },
-    "wof:country":"",
+    "wof:country":"NC",
     "wof:created":1469052385,
-    "wof:geomhash":"cd10f04a2122f08ec27b91939ea60dba",
+    "wof:geomhash":"891dab00e59c045661a5cd9c4707480f",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -322,7 +322,7 @@
         }
     ],
     "wof:id":890442889,
-    "wof:lastmodified":1690923884,
+    "wof:lastmodified":1695887130,
     "wof:name":"Lifou",
     "wof:parent_id":85675251,
     "wof:placetype":"county",

--- a/data/890/443/115/890443115.geojson
+++ b/data/890/443/115/890443115.geojson
@@ -77,7 +77,7 @@
         }
     ],
     "wof:id":890443115,
-    "wof:lastmodified":1694492509,
+    "wof:lastmodified":1695886294,
     "wof:name":"Hao",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/890/449/665/890449665.geojson
+++ b/data/890/449/665/890449665.geojson
@@ -139,7 +139,7 @@
     },
     "wof:country":"",
     "wof:created":1469052702,
-    "wof:geomhash":"ad28836a1eb3d5de72a4c657d5ac3c6b",
+    "wof:geomhash":"176558b990c14a1fc6ce7f9d1c50ac7e",
     "wof:hierarchy":[
         {
             "continent_id":-1,
@@ -148,7 +148,7 @@
         }
     ],
     "wof:id":890449665,
-    "wof:lastmodified":1690923874,
+    "wof:lastmodified":1695884281,
     "wof:name":"Dededo",
     "wof:parent_id":-1,
     "wof:placetype":"region",

--- a/data/890/449/667/890449667.geojson
+++ b/data/890/449/667/890449667.geojson
@@ -52,7 +52,7 @@
     },
     "wof:country":"",
     "wof:created":1469052702,
-    "wof:geomhash":"ee50213ffc03bd57412847688a19416d",
+    "wof:geomhash":"f30f48fa1ec88db12ea47095f61cc3bc",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -63,7 +63,7 @@
         }
     ],
     "wof:id":890449667,
-    "wof:lastmodified":1627523011,
+    "wof:lastmodified":1695884285,
     "wof:name":"Yigo",
     "wof:parent_id":85632163,
     "wof:placetype":"region",

--- a/data/890/449/671/890449671.geojson
+++ b/data/890/449/671/890449671.geojson
@@ -66,7 +66,7 @@
     },
     "wof:country":"",
     "wof:created":1469052702,
-    "wof:geomhash":"4d7290b5aca0deb38eb600c69c735ed2",
+    "wof:geomhash":"7818d89a7d85b4ea96bbcb43750b1b2f",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -77,7 +77,7 @@
         }
     ],
     "wof:id":890449671,
-    "wof:lastmodified":1566657564,
+    "wof:lastmodified":1695884328,
     "wof:name":"Agat",
     "wof:parent_id":85632163,
     "wof:placetype":"region",

--- a/data/890/449/673/890449673.geojson
+++ b/data/890/449/673/890449673.geojson
@@ -52,7 +52,7 @@
     },
     "wof:country":"",
     "wof:created":1469052702,
-    "wof:geomhash":"728cb19a2116369985605e637e4a92b0",
+    "wof:geomhash":"885b47230fb15d4a03ebf41b1c6750e7",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -63,7 +63,7 @@
         }
     ],
     "wof:id":890449673,
-    "wof:lastmodified":1627523011,
+    "wof:lastmodified":1695884285,
     "wof:name":"Merizo",
     "wof:parent_id":85632163,
     "wof:placetype":"region",

--- a/data/890/449/675/890449675.geojson
+++ b/data/890/449/675/890449675.geojson
@@ -52,7 +52,7 @@
     },
     "wof:country":"",
     "wof:created":1469052702,
-    "wof:geomhash":"a07e440a0c3ee52d2080debd6fcd463d",
+    "wof:geomhash":"c60b2810614dcd6b6cf7f950556a3741",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -63,7 +63,7 @@
         }
     ],
     "wof:id":890449675,
-    "wof:lastmodified":1627523011,
+    "wof:lastmodified":1695884285,
     "wof:name":"Umatac",
     "wof:parent_id":85632163,
     "wof:placetype":"region",

--- a/data/890/449/679/890449679.geojson
+++ b/data/890/449/679/890449679.geojson
@@ -154,7 +154,7 @@
     },
     "wof:country":"",
     "wof:created":1469052702,
-    "wof:geomhash":"aac4884baa7d98d601c7e8b261aecb12",
+    "wof:geomhash":"6a0d132381c0e8b24f33f050774bf3d0",
     "wof:hierarchy":[
         {
             "continent_id":-1,
@@ -163,7 +163,7 @@
         }
     ],
     "wof:id":890449679,
-    "wof:lastmodified":1636497530,
+    "wof:lastmodified":1695884853,
     "wof:name":"Santa Rita",
     "wof:parent_id":-1,
     "wof:placetype":"region",

--- a/data/890/449/703/890449703.geojson
+++ b/data/890/449/703/890449703.geojson
@@ -58,7 +58,7 @@
     },
     "wof:country":"",
     "wof:created":1469052704,
-    "wof:geomhash":"9550aa56aec502e5240c0e78df9e7953",
+    "wof:geomhash":"bf30116deefc5350c2a6a49a9c203f04",
     "wof:hierarchy":[
         {
             "continent_id":-1,
@@ -67,7 +67,7 @@
         }
     ],
     "wof:id":890449703,
-    "wof:lastmodified":1627523011,
+    "wof:lastmodified":1695884756,
     "wof:name":"Piti",
     "wof:parent_id":-1,
     "wof:placetype":"region",

--- a/data/890/449/705/890449705.geojson
+++ b/data/890/449/705/890449705.geojson
@@ -155,7 +155,7 @@
     },
     "wof:country":"",
     "wof:created":1469052704,
-    "wof:geomhash":"977d7bc2ead3ba8db60261d1e4d8f151",
+    "wof:geomhash":"f3f3ee49ac060b8e5bd45344791bb1e9",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -166,7 +166,7 @@
         }
     ],
     "wof:id":890449705,
-    "wof:lastmodified":1566657563,
+    "wof:lastmodified":1695884328,
     "wof:name":"Asan",
     "wof:parent_id":85632163,
     "wof:placetype":"region",

--- a/data/890/449/707/890449707.geojson
+++ b/data/890/449/707/890449707.geojson
@@ -50,7 +50,7 @@
     },
     "wof:country":"",
     "wof:created":1469052704,
-    "wof:geomhash":"ebc46de6a5ebb768f71bd293a01c8ba9",
+    "wof:geomhash":"7cfcd40bc283372b091d16bac885ec01",
     "wof:hierarchy":[
         {
             "continent_id":-1,
@@ -59,7 +59,7 @@
         }
     ],
     "wof:id":890449707,
-    "wof:lastmodified":1636497530,
+    "wof:lastmodified":1695884286,
     "wof:name":"Agana",
     "wof:parent_id":-1,
     "wof:placetype":"region",

--- a/data/890/449/747/890449747.geojson
+++ b/data/890/449/747/890449747.geojson
@@ -211,6 +211,7 @@
         "wd:id":"Q642787",
         "wk:page":"Atafu"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"",
     "wof:created":1469052707,
     "wof:geomhash":"8a2d2ae9daf4c9c3f1c9bdd385635806",
@@ -222,7 +223,7 @@
         }
     ],
     "wof:id":890449747,
-    "wof:lastmodified":1695884853,
+    "wof:lastmodified":1696023163,
     "wof:name":"Atafu",
     "wof:parent_id":-1,
     "wof:placetype":"region",

--- a/data/890/449/747/890449747.geojson
+++ b/data/890/449/747/890449747.geojson
@@ -213,7 +213,7 @@
     },
     "wof:country":"",
     "wof:created":1469052707,
-    "wof:geomhash":"12b914e311f7b524336e74818e79b112",
+    "wof:geomhash":"8a2d2ae9daf4c9c3f1c9bdd385635806",
     "wof:hierarchy":[
         {
             "continent_id":-1,
@@ -222,7 +222,7 @@
         }
     ],
     "wof:id":890449747,
-    "wof:lastmodified":1690923871,
+    "wof:lastmodified":1695884853,
     "wof:name":"Atafu",
     "wof:parent_id":-1,
     "wof:placetype":"region",

--- a/data/890/449/751/890449751.geojson
+++ b/data/890/449/751/890449751.geojson
@@ -174,7 +174,7 @@
     },
     "wof:country":"",
     "wof:created":1469052707,
-    "wof:geomhash":"15c945e7f45232f4b333679da321b046",
+    "wof:geomhash":"c8c32e1cb4c2d2d8fb949423a219df4c",
     "wof:hierarchy":[
         {
             "continent_id":-1,
@@ -183,7 +183,7 @@
         }
     ],
     "wof:id":890449751,
-    "wof:lastmodified":1690923873,
+    "wof:lastmodified":1695884328,
     "wof:name":"Nukunonu",
     "wof:parent_id":-1,
     "wof:placetype":"region",

--- a/data/890/449/751/890449751.geojson
+++ b/data/890/449/751/890449751.geojson
@@ -172,6 +172,7 @@
         "wd:id":"Q656709",
         "wk:page":"Nukunonu"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"",
     "wof:created":1469052707,
     "wof:geomhash":"c8c32e1cb4c2d2d8fb949423a219df4c",
@@ -183,7 +184,7 @@
         }
     ],
     "wof:id":890449751,
-    "wof:lastmodified":1695884328,
+    "wof:lastmodified":1696023163,
     "wof:name":"Nukunonu",
     "wof:parent_id":-1,
     "wof:placetype":"region",

--- a/data/890/449/753/890449753.geojson
+++ b/data/890/449/753/890449753.geojson
@@ -177,7 +177,7 @@
     },
     "wof:country":"",
     "wof:created":1469052707,
-    "wof:geomhash":"4215f11372782c82e8f78e05be0dbda5",
+    "wof:geomhash":"be2c9d05bbf32efd22edcd1ac0b4cffc",
     "wof:hierarchy":[
         {
             "continent_id":-1,
@@ -186,7 +186,7 @@
         }
     ],
     "wof:id":890449753,
-    "wof:lastmodified":1690923870,
+    "wof:lastmodified":1695884328,
     "wof:name":"Fakaofo",
     "wof:parent_id":-1,
     "wof:placetype":"region",

--- a/data/890/449/753/890449753.geojson
+++ b/data/890/449/753/890449753.geojson
@@ -175,6 +175,7 @@
         "wd:id":"Q650847",
         "wk:page":"Fakaofo"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"",
     "wof:created":1469052707,
     "wof:geomhash":"be2c9d05bbf32efd22edcd1ac0b4cffc",
@@ -186,7 +187,7 @@
         }
     ],
     "wof:id":890449753,
-    "wof:lastmodified":1695884328,
+    "wof:lastmodified":1696023163,
     "wof:name":"Fakaofo",
     "wof:parent_id":-1,
     "wof:placetype":"region",

--- a/data/890/449/809/890449809.geojson
+++ b/data/890/449/809/890449809.geojson
@@ -47,7 +47,7 @@
     },
     "wof:country":"",
     "wof:created":1469052711,
-    "wof:geomhash":"91770b9267b5ac46331b7fdda0066390",
+    "wof:geomhash":"4fe38ce00325cb79af24383914d32dfb",
     "wof:hierarchy":[
         {
             "continent_id":-1,
@@ -56,7 +56,7 @@
         }
     ],
     "wof:id":890449809,
-    "wof:lastmodified":1627523011,
+    "wof:lastmodified":1695884285,
     "wof:name":"North Eastern",
     "wof:parent_id":-1,
     "wof:placetype":"region",

--- a/data/890/451/881/890451881.geojson
+++ b/data/890/451/881/890451881.geojson
@@ -54,7 +54,7 @@
         }
     ],
     "wof:id":890451881,
-    "wof:lastmodified":1694492294,
+    "wof:lastmodified":1695887130,
     "wof:name":"\u0639\u062c\u0645\u0627\u0646",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/890/451/951/890451951.geojson
+++ b/data/890/451/951/890451951.geojson
@@ -77,7 +77,7 @@
     },
     "wof:country":"",
     "wof:created":1469052798,
-    "wof:geomhash":"f762d31acb461c9004fd3c14f4a361a9",
+    "wof:geomhash":"bf018ed766d0c4b4b157376c39c1421e",
     "wof:hierarchy":[
         {
             "continent_id":-1,
@@ -87,7 +87,7 @@
         }
     ],
     "wof:id":890451951,
-    "wof:lastmodified":1690923886,
+    "wof:lastmodified":1695887126,
     "wof:name":"Serasa",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/890/451/983/890451983.geojson
+++ b/data/890/451/983/890451983.geojson
@@ -10,7 +10,7 @@
     "geom:latitude":-22.58485,
     "geom:longitude":167.509746,
     "gp:adm0":23424903,
-    "iso:country":"",
+    "iso:country":"NC",
     "label:eng_x_preferred_longname":[
         "\u00cele des Pins County"
     ],
@@ -50,7 +50,7 @@
         "gp:id":24551445,
         "qs_pg:id":220269
     },
-    "wof:country":"",
+    "wof:country":"NC",
     "wof:created":1469052800,
     "wof:geomhash":"07a3e28c3f942f346b234f2dc60dcfe5",
     "wof:hierarchy":[
@@ -64,7 +64,7 @@
         }
     ],
     "wof:id":890451983,
-    "wof:lastmodified":1694492300,
+    "wof:lastmodified":1695887128,
     "wof:name":"\u00cele des Pins",
     "wof:parent_id":85675259,
     "wof:placetype":"county",

--- a/data/890/451/985/890451985.geojson
+++ b/data/890/451/985/890451985.geojson
@@ -129,7 +129,7 @@
         }
     ],
     "wof:id":890451985,
-    "wof:lastmodified":1694492928,
+    "wof:lastmodified":1695886737,
     "wof:name":"Central",
     "wof:parent_id":85681419,
     "wof:placetype":"county",

--- a/data/890/451/987/890451987.geojson
+++ b/data/890/451/987/890451987.geojson
@@ -117,6 +117,7 @@
         "hasc:id":"LB.JA.SA",
         "qs_pg:id":220663
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"",
     "wof:created":1469052800,
     "wof:geom_alt":[
@@ -132,7 +133,7 @@
         }
     ],
     "wof:id":890451987,
-    "wof:lastmodified":1694492928,
+    "wof:lastmodified":1695886738,
     "wof:name":"Saida",
     "wof:parent_id":85673499,
     "wof:placetype":"county",

--- a/data/890/452/005/890452005.geojson
+++ b/data/890/452/005/890452005.geojson
@@ -10,7 +10,7 @@
     "geom:latitude":-22.139075,
     "geom:longitude":166.702251,
     "gp:adm0":23424903,
-    "iso:country":"",
+    "iso:country":"NC",
     "label:eng_x_preferred_longname":[
         "Yate County"
     ],
@@ -117,7 +117,7 @@
         "qs_pg:id":221552,
         "wk:page":"Yate"
     },
-    "wof:country":"",
+    "wof:country":"NC",
     "wof:created":1469052801,
     "wof:geomhash":"f5f8f299dd208dab3c7d63641fd4c236",
     "wof:hierarchy":[
@@ -131,7 +131,7 @@
         }
     ],
     "wof:id":890452005,
-    "wof:lastmodified":1694492509,
+    "wof:lastmodified":1695886294,
     "wof:name":"Yate",
     "wof:parent_id":85675259,
     "wof:placetype":"county",

--- a/data/890/452/007/890452007.geojson
+++ b/data/890/452/007/890452007.geojson
@@ -10,7 +10,7 @@
     "geom:latitude":-21.708791,
     "geom:longitude":166.395578,
     "gp:adm0":23424903,
-    "iso:country":"",
+    "iso:country":"NC",
     "label:eng_x_preferred_longname":[
         "Thio County"
     ],
@@ -61,7 +61,7 @@
         "qs_pg:id":221553,
         "wk:page":"Thio"
     },
-    "wof:country":"",
+    "wof:country":"NC",
     "wof:created":1469052801,
     "wof:geomhash":"6e5994ab76a3025d99265edb1b8f786a",
     "wof:hierarchy":[
@@ -75,7 +75,7 @@
         }
     ],
     "wof:id":890452007,
-    "wof:lastmodified":1694492824,
+    "wof:lastmodified":1695886233,
     "wof:name":"Thio",
     "wof:parent_id":85675259,
     "wof:placetype":"county",

--- a/data/890/452/009/890452009.geojson
+++ b/data/890/452/009/890452009.geojson
@@ -10,7 +10,7 @@
     "geom:latitude":-21.804133,
     "geom:longitude":165.811157,
     "gp:adm0":23424903,
-    "iso:country":"",
+    "iso:country":"NC",
     "label:eng_x_preferred_longname":[
         "La Foa County"
     ],
@@ -344,9 +344,9 @@
         "wd:id":"Q9727",
         "wk:page":"La Foa"
     },
-    "wof:country":"",
+    "wof:country":"NC",
     "wof:created":1469052801,
-    "wof:geomhash":"4b6d22c04ab63e1672562da51221a6e6",
+    "wof:geomhash":"02b62bf4f49252dbc1befcd4765e314e",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -358,7 +358,7 @@
         }
     ],
     "wof:id":890452009,
-    "wof:lastmodified":1690923880,
+    "wof:lastmodified":1695887130,
     "wof:name":"La Foa",
     "wof:parent_id":85675259,
     "wof:placetype":"county",

--- a/data/890/452/011/890452011.geojson
+++ b/data/890/452/011/890452011.geojson
@@ -10,7 +10,7 @@
     "geom:latitude":-21.605726,
     "geom:longitude":165.461826,
     "gp:adm0":23424903,
-    "iso:country":"",
+    "iso:country":"NC",
     "label:eng_x_preferred_longname":[
         "Houa\u00eflou County"
     ],
@@ -293,9 +293,9 @@
         "wd:id":"Q9716",
         "wk:page":"Houa\u00eflou"
     },
-    "wof:country":"",
+    "wof:country":"NC",
     "wof:created":1469052801,
-    "wof:geomhash":"7b0cfa412f59034e37037d99544d318d",
+    "wof:geomhash":"e6beac7453905cee7a6c82ec01e6b6ef",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -307,7 +307,7 @@
         }
     ],
     "wof:id":890452011,
-    "wof:lastmodified":1690923881,
+    "wof:lastmodified":1695887130,
     "wof:name":"Houa\u00eflou",
     "wof:parent_id":85675259,
     "wof:placetype":"county",

--- a/data/890/452/059/890452059.geojson
+++ b/data/890/452/059/890452059.geojson
@@ -175,7 +175,7 @@
     },
     "wof:country":"",
     "wof:created":1469052802,
-    "wof:geomhash":"7d2e097d37dbb8683c6eea0dfe11675a",
+    "wof:geomhash":"f2a0a97032698d2b1596c82f6b815833",
     "wof:hierarchy":[
         {
             "continent_id":-1,
@@ -185,7 +185,7 @@
         }
     ],
     "wof:id":890452059,
-    "wof:lastmodified":1690923883,
+    "wof:lastmodified":1695887148,
     "wof:name":"Huahine",
     "wof:parent_id":85676731,
     "wof:placetype":"county",

--- a/data/890/452/083/890452083.geojson
+++ b/data/890/452/083/890452083.geojson
@@ -52,7 +52,7 @@
     },
     "wof:country":"",
     "wof:created":1469052804,
-    "wof:geomhash":"bb7e5d1e71d863e4165887fcc3a3c411",
+    "wof:geomhash":"2be35e31c4f351b6255e31a6691ad16a",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -63,7 +63,7 @@
         }
     ],
     "wof:id":890452083,
-    "wof:lastmodified":1627523011,
+    "wof:lastmodified":1695884285,
     "wof:name":"Mangilao",
     "wof:parent_id":85632163,
     "wof:placetype":"region",

--- a/data/890/452/237/890452237.geojson
+++ b/data/890/452/237/890452237.geojson
@@ -127,7 +127,7 @@
     },
     "wof:country":"",
     "wof:created":1469052809,
-    "wof:geomhash":"ea55f6f30f50b775a4b82a3da111a417",
+    "wof:geomhash":"51890ba18e4fa9a507b7ba81eba7632f",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -139,7 +139,7 @@
         }
     ],
     "wof:id":890452237,
-    "wof:lastmodified":1636497532,
+    "wof:lastmodified":1695887148,
     "wof:name":"East End",
     "wof:parent_id":85680571,
     "wof:placetype":"county",

--- a/data/890/452/239/890452239.geojson
+++ b/data/890/452/239/890452239.geojson
@@ -63,7 +63,7 @@
         }
     ],
     "wof:id":890452239,
-    "wof:lastmodified":1694492301,
+    "wof:lastmodified":1695887128,
     "wof:name":"Northcentral",
     "wof:parent_id":85680579,
     "wof:placetype":"county",

--- a/data/890/452/243/890452243.geojson
+++ b/data/890/452/243/890452243.geojson
@@ -54,7 +54,7 @@
         }
     ],
     "wof:id":890452243,
-    "wof:lastmodified":1694492294,
+    "wof:lastmodified":1695887451,
     "wof:name":"\u0627\u0644\u0623\u062d\u0645\u062f\u0649",
     "wof:parent_id":-1,
     "wof:placetype":"county",


### PR DESCRIPTION
Will fix a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/2164. Sets wof:concordances_official, wof:concordances_official_alt, and wof:label_*_x_preferred properties, and wof:concordances{*:*} hashes when approprirate.